### PR TITLE
[patch] Release 1.0.1 — CI fixes and release automation

### DIFF
--- a/cc-hdrm/Info.plist
+++ b/cc-hdrm/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.0</string>
+	<string>1.0.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
## Summary

- Fixed CI: upgraded to Xcode 26.2, fixed Swift 6 strict concurrency errors
- Fixed notification tests: replaced unmockable UNNotificationSettings with protocol method
- Added automated post-merge release pipeline (Story 7.3)
- Added explicit XcodeGen scheme with test target discovery

<!-- release-notes-start -->
### Highlights

- CI now builds and tests on Xcode 26.2 (Swift 6.2)
- Automated release pipeline: merging a PR with `[patch]`, `[minor]`, or `[major]` in the title triggers a full build-package-publish cycle
- Fixed flaky notification tests in CI environment
<!-- release-notes-end -->