### PR TITLE
docs: Phase 3 planning documents

### DIFF
--- a/_bmad-output/planning-artifacts/architecture.md
+++ b/_bmad-output/planning-artifacts/architecture.md
@@ -1,16 +1,20 @@
 ---
-stepsCompleted: [1, 2, 3, 4, 5, 6, 7, 8]
+stepsCompleted: [1, 2, 3, 4, 5, 6, 7, 8, 9]
 status: 'complete'
-completedAt: '2026-01-31'
-lastStep: 8
+completedAt: '2026-02-03'
+lastStep: 9
 inputDocuments:
   - _bmad-output/planning-artifacts/prd.md
   - _bmad-output/planning-artifacts/product-brief-cc-usage-2026-01-30.md
   - _bmad-output/planning-artifacts/ux-design-specification.md
+  - _bmad-output/planning-artifacts/ux-design-specification-phase3.md
 workflowType: 'architecture'
 project_name: 'cc-hdrm'
 user_name: 'Boss'
-date: '2026-01-31'
+date: '2026-02-03'
+editHistory:
+  - date: '2026-02-03'
+    changes: 'Added Phase 3 architectural decisions: SQLite persistence, slope calculation, headroom analysis, analytics window'
 ---
 
 # Architecture Decision Document
@@ -774,34 +778,739 @@ cc-hdrm/
               (poll interval) (thresholds)
 ```
 
+## Phase 3 Architectural Additions
+
+Phase 3 transforms cc-hdrm from a real-time fuel gauge into a historical analytics platform. Three interconnected features require significant architectural expansion:
+
+1. **Historical Usage Tracking** — SQLite persistence, rollup engine, analytics window
+2. **Underutilised Headroom Analysis** — Credit math, waste categorization, three-band visualization
+3. **Usage Slope Indicator** — Rate-of-change calculation, discrete 4-level display
+
+### Data Layer Architecture
+
+**First persistent storage.** Phase 1-2 were entirely in-memory. Phase 3 introduces SQLite for historical data.
+
+#### Database Location
+
+**Path:** `~/Library/Application Support/cc-hdrm/usage.db`
+
+**Rationale:** Standard macOS convention for application data. Survives app updates, keeps data separate from app bundle.
+
+#### SQLite Schema
+
+**Table: `usage_polls`** — Raw poll data, < 24h retention at full resolution
+
+| Column              | Type    | Notes                      |
+| ------------------- | ------- | -------------------------- |
+| id                  | INTEGER | PRIMARY KEY                |
+| timestamp           | INTEGER | Unix ms                    |
+| five_hour_util      | REAL    | Percentage 0-100           |
+| five_hour_resets_at | INTEGER | Unix ms, nullable          |
+| seven_day_util      | REAL    | Percentage 0-100           |
+| seven_day_resets_at | INTEGER | Unix ms, nullable          |
+
+**Table: `usage_rollups`** — Aggregated data at decreasing resolution
+
+| Column          | Type    | Notes                              |
+| --------------- | ------- | ---------------------------------- |
+| id              | INTEGER | PRIMARY KEY                        |
+| period_start    | INTEGER | Unix ms                            |
+| period_end      | INTEGER | Unix ms                            |
+| resolution      | TEXT    | '5min' \| 'hourly' \| 'daily'      |
+| five_hour_avg   | REAL    | Average utilization for period     |
+| five_hour_peak  | REAL    | Maximum utilization for period     |
+| five_hour_min   | REAL    | Minimum utilization for period     |
+| seven_day_avg   | REAL    |                                    |
+| seven_day_peak  | REAL    |                                    |
+| seven_day_min   | REAL    |                                    |
+| reset_count     | INTEGER | Number of 5h resets in period      |
+| waste_credits   | REAL    | Calculated true waste              |
+
+**Table: `reset_events`** — Captures each 5h window reset for headroom analysis
+
+| Column              | Type    | Notes                         |
+| ------------------- | ------- | ----------------------------- |
+| id                  | INTEGER | PRIMARY KEY                   |
+| timestamp           | INTEGER | Unix ms                       |
+| five_hour_peak      | REAL    | Peak utilization before reset |
+| seven_day_util      | REAL    | 7d utilization at reset time  |
+| tier                | TEXT    | Rate limit tier string        |
+| used_credits        | REAL    | Actual consumption            |
+| constrained_credits | REAL    | 7d-blocked capacity           |
+| waste_credits       | REAL    | True waste                    |
+
+**Indexes:**
+- `usage_polls(timestamp)` — for range queries
+- `usage_rollups(resolution, period_start)` — for rollup lookups
+- `reset_events(timestamp)` — for headroom analysis
+
+#### Rollup Strategy
+
+**Trigger:** On-demand when analytics window opens.
+
+**Rationale:** CPU consumed only when user explicitly requests analytics. Zero rollup overhead if user never opens analytics window. User clicked something — they expect processing.
+
+**Implementation:**
+1. Track `last_rollup_timestamp` in database metadata
+2. On analytics open, call `HistoricalDataService.ensureRollupsUpToDate()`
+3. Process only records newer than last rollup
+4. Typical case: < 100ms for a day's worth of polls
+
+**Tiered Resolution:**
+
+| Data Age   | Resolution        | Rollup Action                    |
+| ---------- | ----------------- | -------------------------------- |
+| < 24 hours | Per-poll (~60s)   | Keep raw, no rollup              |
+| 1-7 days   | 5-minute averages | Aggregate raw → 5min rollups     |
+| 7-30 days  | Hourly averages   | Aggregate 5min → hourly rollups  |
+| 30+ days   | Daily summary     | Aggregate hourly → daily rollups |
+
+**Retention:** Configurable via settings, default 1 year. Enforced by `pruneOldData()` called during rollup.
+
+### New Services
+
+#### HistoricalDataService
+
+**Responsibility:** SQLite persistence, rollup engine, data queries.
+
+```swift
+protocol HistoricalDataServiceProtocol {
+    func persistPoll(_ response: UsageResponse) async throws
+    func ensureRollupsUpToDate() async throws
+    func getRecentPolls(hours: Int) async throws -> [UsagePoll]
+    func getRolledUpData(range: TimeRange) async throws -> [UsageRollup]
+    func getResetEvents(range: TimeRange) async throws -> [ResetEvent]
+    func pruneOldData(retentionDays: Int) async throws
+    func getDatabaseSize() async throws -> Int64
+}
+```
+
+**Reset Detection:** Primary: compare `resets_at` timestamps between consecutive polls. Fallback: detect large utilization drops (e.g., 80% → 2%) to catch edge cases where `resets_at` is missing.
+
+#### SlopeCalculationService
+
+**Responsibility:** Rate-of-change calculation, discrete level mapping.
+
+```swift
+protocol SlopeCalculationServiceProtocol {
+    func addPoll(_ poll: UsagePoll)
+    func calculateSlope(for window: UsageWindow) -> SlopeLevel
+    func bootstrapFromHistory(_ polls: [UsagePoll])
+}
+
+enum SlopeLevel: String {
+    case cooling  // ↘ utilization decreasing
+    case flat     // → no meaningful change
+    case rising   // ↗ moderate consumption
+    case steep    // ⬆ heavy consumption
+}
+```
+
+**Data Source:** In-memory ring buffer holding last 10-15 minutes of polls (~15-30 data points). On app launch, bootstrap buffer from SQLite via `HistoricalDataService.getRecentPolls(hours: 1)`.
+
+**Calculation:**
+1. Sample buffer for specified window (5h or 7d)
+2. Compute average rate of change (% per minute)
+3. Map to discrete level:
+
+| Rate (% / min) | Level   |
+| -------------- | ------- |
+| < -0.5         | Cooling |
+| -0.5 to 0.3    | Flat    |
+| 0.3 to 1.5     | Rising  |
+| > 1.5          | Steep   |
+
+**Trigger:** Recalculate on every poll cycle. Slope calculation is trivial (average of ~15-30 numbers from in-memory buffer). Ensures menu bar slope arrow is always current.
+
+#### HeadroomAnalysisService
+
+**Responsibility:** Waste categorization math, credit limit lookup.
+
+```swift
+protocol HeadroomAnalysisServiceProtocol {
+    func analyzeResetEvent(peak5h: Double, util7d: Double, tier: RateLimitTier) -> HeadroomBreakdown
+    func aggregateBreakdown(_ events: [ResetEvent]) -> PeriodSummary
+    func getCreditLimits(for tier: RateLimitTier) -> (fiveHour: Int, sevenDay: Int)?
+}
+
+struct HeadroomBreakdown {
+    let usedPercent: Double
+    let constrainedPercent: Double  // 7d-blocked, NOT waste
+    let wastePercent: Double        // true waste
+    let usedCredits: Int
+    let constrainedCredits: Int
+    let wasteCredits: Int
+}
+```
+
+**Waste Calculation (at each 5h reset):**
+
+```
+5h_remaining_credits = (100% - 5h_peak%) × 5h_limit
+7d_remaining_credits = (100% - 7d_util%) × 7d_limit
+effective_headroom_credits = min(5h_remaining_credits, 7d_remaining_credits)
+
+If 5h_remaining ≤ 7d_remaining:
+    true_waste = 5h_remaining  (all unused 5h was genuinely available)
+    7d_constrained = 0
+Else:
+    true_waste = 7d_remaining  (7d was the binding constraint)
+    7d_constrained = 5h_remaining - 7d_remaining
+```
+
+#### DatabaseManager
+
+**Responsibility:** SQLite connection, schema creation, migrations.
+
+```swift
+protocol DatabaseManagerProtocol {
+    func getConnection() throws -> Connection
+    func ensureSchema() throws
+    func runMigrations() throws
+}
+```
+
+**Location:** `~/Library/Application Support/cc-hdrm/usage.db`
+
+**Schema creation:** On first launch, create tables and indexes. Track schema version for future migrations.
+
+### Credit Limit Handling
+
+**Source:** Hardcoded lookup table + user override in settings for power users / new tiers.
+
+```swift
+enum RateLimitTier: String, CaseIterable {
+    case pro = "default_claude_pro"
+    case max5x = "default_claude_max_5x"
+    case max20x = "default_claude_max_20x"
+    
+    var fiveHourCredits: Int {
+        switch self {
+        case .pro: return 550_000
+        case .max5x: return 3_300_000
+        case .max20x: return 11_000_000
+        }
+    }
+    
+    var sevenDayCredits: Int {
+        switch self {
+        case .pro: return 5_000_000
+        case .max5x: return 41_666_700
+        case .max20x: return 83_333_300
+        }
+    }
+}
+```
+
+**User Override:** Settings view includes optional fields for custom 5h/7d credit limits. If set, override the hardcoded values. Stored in `PreferencesManager`.
+
+**Unknown Tier Handling:** If `rateLimitTier` from Keychain doesn't match known values AND no user override:
+- Log warning for debugging
+- Headroom breakdown section shows: "Headroom breakdown unavailable — unknown subscription tier."
+- Percentage-based displays continue working normally
+
+### Analytics Window Architecture
+
+**First real window.** Phase 1-2 UI was entirely menu bar + popover. Phase 3 adds a detachable analytics panel.
+
+#### Window Type
+
+**NSPanel (utility window)** with `.nonactivatingPanel` style.
+
+| Property       | Behavior                                          |
+| -------------- | ------------------------------------------------- |
+| Dock icon      | None — app stays LSUIElement                      |
+| Cmd+Tab        | Not included                                      |
+| Window level   | Floats above regular windows, below fullscreen    |
+| Activation     | Non-activating — doesn't steal focus from user's app |
+| Close          | Close button + Escape key                         |
+| Size           | Default ~600×500px, resizable, remembers position |
+
+#### Window Controller
+
+```swift
+class AnalyticsWindowController {
+    static let shared = AnalyticsWindowController()  // Singleton
+    
+    private var panel: NSPanel?
+    @Published var isOpen: Bool = false
+    
+    func toggle() {
+        if isOpen { close() } else { open() }
+    }
+    
+    func open() {
+        if panel == nil { createPanel() }  // Lazy creation
+        panel?.makeKeyAndOrderFront(nil)
+        isOpen = true
+    }
+    
+    func close() {
+        panel?.close()
+        isOpen = false
+    }
+}
+```
+
+**Lifecycle:**
+- Singleton — only one analytics window ever exists
+- Lazy creation — window instantiated on first open
+- Toggle behavior — sparkline click opens OR brings to front
+- State persistence — frame saved to UserDefaults
+- Escape key handling — closes window
+
+#### Window-Popover Relationship
+
+**Independent.** Both can be visible simultaneously.
+
+**Rationale:** Popover is "quick glance," analytics is "deep dive." User may want both: check current state in popover while historical chart is visible in analytics window.
+
+#### Data Loading
+
+**Load all upfront** when window opens or time range changes.
+
+**Rationale:** At 1-year retention with daily rollups, "All" view is ~365 data points. Trivial to load entirely. No pagination complexity needed.
+
+### Component Modifications
+
+#### MenuBarTextRenderer (Phase 1 component)
+
+**Modification:** Add optional slope arrow suffix (escalation-only).
+
+**New rendering logic:**
+```swift
+func renderMenuBarText() -> String {
+    guard connectionStatus != .disconnected else { return "✳ —" }
+    guard headroomState != .exhausted else { return "✳ ↻ \(countdown)" }
+    
+    let base = "✳ \(percentage)%"
+    
+    // Phase 3: append slope only for Rising/Steep
+    switch fiveHourSlope {
+    case .rising: return "\(base) ↗"
+    case .steep:  return "\(base) ⬆"
+    case .flat, .cooling: return base
+    }
+}
+```
+
+**Width impact:** +2 characters when slope visible (~7 chars max vs ~5 chars Phase 1-2).
+
+#### HeadroomRingGauge (Phase 1 component)
+
+**Modification:** Add `SlopeIndicator` view below percentage.
+
+**New layout:**
+```
+    ◯ (ring)
+     78%
+      ↗         ← NEW: slope indicator (always visible in popover)
+resets in 1h 12m
+  at 5:17 PM
+```
+
+**Props addition:** `slopeLevel: SlopeLevel`
+
+#### PopoverView (Phase 1 component)
+
+**Modification:** Add sparkline section between 7d gauge and footer.
+
+**New structure:**
+```
+┌──────────────────┐
+│  5h gauge + slope│
+│  7d gauge + slope│
+├──────────────────┤
+│  24h Sparkline   │  ← NEW: clickable, launches analytics
+├──────────────────┤
+│  Footer          │
+└──────────────────┘
+```
+
+**Sparkline data:** Cached in `AppState.sparklineData`, refreshed on each poll cycle. Popover opens instantly — no data fetch on open.
+
+### New Components
+
+#### SlopeIndicator
+
+**Purpose:** Display discrete slope arrow with appropriate styling.
+
+```swift
+struct SlopeIndicator: View {
+    let level: SlopeLevel
+    let size: CGFloat
+    
+    var body: some View {
+        Text(level.arrow)
+            .font(.system(size: size))
+            .foregroundColor(level.color)
+            .accessibilityLabel(level.accessibilityLabel)
+    }
+}
+
+extension SlopeLevel {
+    var arrow: String {
+        switch self {
+        case .cooling: return "↘"
+        case .flat: return "→"
+        case .rising: return "↗"
+        case .steep: return "⬆"
+        }
+    }
+    
+    var color: Color {
+        switch self {
+        case .cooling, .flat: return .secondary
+        case .rising, .steep: return .headroomColor  // matches current headroom state
+        }
+    }
+}
+```
+
+#### Sparkline
+
+**Purpose:** Compact 24h usage visualization, acts as button to launch analytics.
+
+```swift
+struct Sparkline: View {
+    let data: [UsagePoll]
+    let isAnalyticsOpen: Bool
+    let onTap: () -> Void
+    
+    // Renders step-area path honoring sawtooth shape
+    // Gaps as path breaks (no interpolation)
+    // Subtle hover/press state
+    // Indicator dot when analytics window is open
+}
+```
+
+**Accessibility:** "24-hour usage chart. Double-tap to open analytics."
+
+#### AnalyticsView
+
+**Purpose:** Main content view for analytics window.
+
+**Layout:**
+```
+┌─────────────────────────────────────────────────────────┐
+│  Usage Analytics                                    ✕   │
+├─────────────────────────────────────────────────────────┤
+│                                                         │
+│  [24h]  [7d]  [30d]  [All]          5h ● │ 7d ○        │
+│                                                         │
+│  ┌─────────────────────────────────────────────────┐   │
+│  │              UsageChart                          │   │
+│  │   (step-area for 24h, bars for 7d+)             │   │
+│  └─────────────────────────────────────────────────┘   │
+│                                                         │
+├─────────────────────────────────────────────────────────┤
+│  Headroom Breakdown (selected period)                   │
+│  ┌─────────────────────────────────────────────────┐    │
+│  │▓▓▓▓▓▓▓▓▓▓▓▓▓░░░░░░░░░░░                       │    │
+│  └─────────────────────────────────────────────────┘    │
+│  ▓ Used: 52%   ░ 7d-constrained: 12%   □ Waste: 36%    │
+│                                                         │
+│  Avg peak: 64%  │  Total waste: 2.1M credits           │
+└─────────────────────────────────────────────────────────┘
+```
+
+#### UsageChart
+
+**Purpose:** Main chart supporting both step-area and bar modes.
+
+**Props:**
+- `data: [UsageDataPoint]` or `[UsageRollup]`
+- `timeRange: TimeRange` — determines chart type
+- `visibleSeries: Set<Series>` — 5h/7d toggles
+- `showSlopeBands: Bool` — background color bands for steep periods
+
+**Rendering by time range:**
+- **24h:** Step-area chart honoring sawtooth shape, reset markers as dashed vertical lines
+- **7d+:** Bar chart with peak values per period
+
+**Gap handling:** Missing segments rendered as breaks, never interpolated. Hatched/grey region with "No data" hover label.
+
+#### HeadroomBreakdownBar
+
+**Purpose:** Three-band stacked horizontal bar.
+
+```swift
+struct HeadroomBreakdownBar: View {
+    let used: Double
+    let constrained: Double
+    let waste: Double
+    
+    // Rendering:
+    // Used: solid fill, headroom color
+    // 7d-constrained: hatched pattern, muted slate blue
+    // True waste: light/empty fill
+}
+```
+
+**Accessibility:** "Headroom breakdown: 52% used, 12% constrained by weekly limit, 36% unused."
+
+#### TimeRangeSelector
+
+**Purpose:** Segmented control for time range selection.
+
+```swift
+struct TimeRangeSelector: View {
+    @Binding var selected: TimeRange
+    
+    // Four buttons: 24h, 7d, 30d, All
+}
+
+enum TimeRange {
+    case day, week, month, all
+}
+```
+
+### Phase 3 State Additions
+
+**AppState modifications:**
+
+```swift
+@Observable
+class AppState {
+    // Existing Phase 1-2 properties...
+    
+    // Phase 3 additions:
+    var fiveHourSlope: SlopeLevel = .flat
+    var sevenDaySlope: SlopeLevel = .flat
+    var sparklineData: [UsagePoll] = []
+    var isAnalyticsWindowOpen: Bool = false
+}
+```
+
+**Sparkline data refresh:** `PollingEngine` updates `AppState.sparklineData` on each poll by calling `HistoricalDataService.getRecentPolls(hours: 24)`. This keeps popover open instant.
+
+### Phase 3 Settings Additions
+
+**PreferencesManager additions:**
+
+```swift
+// Historical data
+var dataRetentionDays: Int  // default: 365
+
+// Credit limit overrides (for unknown tiers or power users)
+var customFiveHourCredits: Int?   // nil = use hardcoded
+var customSevenDayCredits: Int?   // nil = use hardcoded
+```
+
+**SettingsView additions:**
+- Data retention slider/picker (30 days to 5 years)
+- "Advanced" section for custom credit limits
+- Database size display with "Clear History" button
+
+### Phase 3 Project Structure
+
+```
+cc-hdrm/
+├── cc-hdrm/
+│   ├── Models/
+│   │   ├── SlopeLevel.swift                    # NEW
+│   │   ├── RateLimitTier.swift                 # NEW
+│   │   ├── UsagePoll.swift                     # NEW
+│   │   ├── UsageRollup.swift                   # NEW
+│   │   ├── ResetEvent.swift                    # NEW
+│   │   ├── HeadroomBreakdown.swift             # NEW
+│   │   └── TimeRange.swift                     # NEW
+│   │
+│   ├── Services/
+│   │   ├── HistoricalDataServiceProtocol.swift # NEW
+│   │   ├── HistoricalDataService.swift         # NEW
+│   │   ├── SlopeCalculationServiceProtocol.swift # NEW
+│   │   ├── SlopeCalculationService.swift       # NEW
+│   │   ├── HeadroomAnalysisServiceProtocol.swift # NEW
+│   │   ├── HeadroomAnalysisService.swift       # NEW
+│   │   └── DatabaseManager.swift               # NEW
+│   │
+│   ├── State/
+│   │   └── AppState.swift                      # MODIFIED
+│   │
+│   ├── Views/
+│   │   ├── MenuBarTextRenderer.swift           # MODIFIED
+│   │   ├── HeadroomRingGauge.swift             # MODIFIED
+│   │   ├── PopoverView.swift                   # MODIFIED
+│   │   ├── SettingsView.swift                  # MODIFIED
+│   │   ├── SlopeIndicator.swift                # NEW
+│   │   ├── Sparkline.swift                     # NEW
+│   │   ├── AnalyticsWindow.swift               # NEW
+│   │   ├── AnalyticsView.swift                 # NEW
+│   │   ├── UsageChart.swift                    # NEW
+│   │   ├── HeadroomBreakdownBar.swift          # NEW
+│   │   └── TimeRangeSelector.swift             # NEW
+│   │
+│   ├── Extensions/
+│   │   └── Date+Formatting.swift               # MODIFIED: chart axis formatters
+│   │
+│   └── Resources/
+│       └── Assets.xcassets/
+│           └── AnalyticsColors/                # NEW
+│
+├── cc-hdrmTests/
+│   ├── Models/
+│   │   ├── SlopeLevelTests.swift               # NEW
+│   │   ├── RateLimitTierTests.swift            # NEW
+│   │   └── HeadroomBreakdownTests.swift        # NEW
+│   ├── Services/
+│   │   ├── HistoricalDataServiceTests.swift    # NEW
+│   │   ├── SlopeCalculationServiceTests.swift  # NEW
+│   │   ├── HeadroomAnalysisServiceTests.swift  # NEW
+│   │   └── DatabaseManagerTests.swift          # NEW
+│   └── Views/
+│       ├── SparklineTests.swift                # NEW
+│       └── UsageChartTests.swift               # NEW
+```
+
+### Phase 3 Data Flow
+
+```
+                              ┌─────────────────────┐
+                              │   PollingEngine     │
+                              │   (existing)        │
+                              └──────────┬──────────┘
+                                         │ UsageResponse
+                    ┌────────────────────┼────────────────────┐
+                    │                    │                    │
+                    ▼                    ▼                    ▼
+        ┌───────────────────┐ ┌──────────────────┐ ┌──────────────────┐
+        │ HistoricalData    │ │ SlopeCalculation │ │    AppState      │
+        │ Service           │ │ Service          │ │   (existing)     │
+        │                   │ │                  │ │                  │
+        │ • persistPoll()   │ │ • addToBuffer()  │ │ • updateUsage()  │
+        │ • detectReset()   │ │ • calculate()    │ │ • fiveHourSlope  │
+        │                   │ │     ↓            │ │ • sevenDaySlope  │
+        └────────┬──────────┘ │  SlopeLevel      │ │ • sparklineData  │
+                 │            └────────┬─────────┘ └────────┬─────────┘
+                 │                     │                    │
+                 ▼                     └────────┬───────────┘
+        ┌───────────────────┐                   │ observes
+        │     SQLite        │                   ▼
+        │ ~/Library/App...  │         ┌──────────────────────┐
+        │                   │         │       Views          │
+        │ • usage_polls     │         │                      │
+        │ • usage_rollups   │         │ MenuBarTextRenderer  │◄── slope arrow
+        │ • reset_events    │         │ HeadroomRingGauge    │◄── slope indicator
+        └────────┬──────────┘         │ PopoverView          │◄── sparkline
+                 │                    │ Sparkline ──────────────► click
+                 │                    └──────────────────────┘      │
+                 │                                                  │
+                 │ on-demand query                                  │
+                 │◄─────────────────────────────────────────────────┘
+                 │
+                 ▼
+        ┌───────────────────┐         ┌──────────────────────┐
+        │ HistoricalData    │────────►│   AnalyticsWindow    │
+        │ Service           │ rolled  │   (NSPanel)          │
+        │                   │  data   │                      │
+        │ • ensureRollups() │         │ • UsageChart         │
+        │ • getRolledUp()   │         │ • HeadroomBreakdown  │
+        │ • getResetEvents()│         │ • TimeRangeSelector  │
+        └───────────────────┘         └──────────────────────┘
+                 ▲                               │
+                 │                               ▼
+        ┌────────┴──────────┐         ┌──────────────────────┐
+        │ HeadroomAnalysis  │◄────────│   Reset Events +     │
+        │ Service           │         │   Tier from Keychain │
+        │                   │         └──────────────────────┘
+        │ • analyzeReset()  │
+        │ • aggregate()     │
+        └───────────────────┘
+```
+
+### Phase 3 Requirements to Structure Mapping
+
+| FR   | Requirement                                | Primary File(s)                                                |
+| ---- | ------------------------------------------ | -------------------------------------------------------------- |
+| FR33 | Persist poll snapshots to SQLite           | `HistoricalDataService.swift`, `DatabaseManager.swift`           |
+| FR34 | Roll up data at decreasing resolution      | `HistoricalDataService.swift`                                    |
+| FR35 | 24h sparkline in popover                   | `Sparkline.swift`, `PopoverView.swift`                           |
+| FR36 | Full analytics window with zoomable charts | `AnalyticsWindow.swift`, `AnalyticsView.swift`, `UsageChart.swift` |
+| FR37 | Render gaps as visually distinct           | `Sparkline.swift`, `UsageChart.swift`                            |
+| FR38 | Configurable retention period              | `PreferencesManager.swift`, `SettingsView.swift`                 |
+| FR39 | Calculate effective headroom               | `HeadroomAnalysisService.swift`                                  |
+| FR40 | Detect resets, classify waste categories   | `HistoricalDataService.swift`, `HeadroomAnalysisService.swift`   |
+| FR41 | Three-band breakdown in analytics          | `HeadroomBreakdownBar.swift`, `AnalyticsView.swift`              |
+| FR42 | Compute usage rate of change               | `SlopeCalculationService.swift`                                  |
+| FR43 | Map rate to 4-level slope indicator        | `SlopeCalculationService.swift`, `SlopeLevel.swift`              |
+| FR44 | Slope indicator in menu bar                | `MenuBarTextRenderer.swift`                                      |
+| FR45 | Per-window slope in popover                | `HeadroomRingGauge.swift`, `SlopeIndicator.swift`                |
+
+### Phase 3 Implementation Patterns
+
+#### Gap Rendering Pattern
+
+Gaps (periods when cc-hdrm wasn't running) are rendered consistently across all visualizations:
+
+| Component            | Gap Rendering                              |
+| -------------------- | ------------------------------------------ |
+| Sparkline            | Break in the line                          |
+| UsageChart (24h)     | Missing segment, no path drawn             |
+| UsageChart (7d+ bars)| Missing bars, "No data" on hover           |
+| HeadroomBreakdown    | Gaps excluded from calculation             |
+
+**Rule:** Never interpolate. The visualization admits what it doesn't know.
+
+#### Slope Communication Pattern
+
+Slope is communicated consistently across all locations:
+
+| Location        | Flat/Cooling | Rising | Steep |
+| --------------- | ------------ | ------ | ----- |
+| Menu bar        | Hidden       | ↗      | ⬆     |
+| Popover 5h      | →/↘          | ↗      | ⬆     |
+| Popover 7d      | →/↘          | ↗      | ⬆     |
+| Analytics chart | No tint      | Tint   | Tint  |
+
+#### Accessibility Pattern
+
+All Phase 3 components maintain color independence:
+
+| Element            | Color Signal      | Non-Color Signal         |
+| ------------------ | ----------------- | ------------------------ |
+| Slope arrow        | Headroom color    | Arrow direction shape    |
+| Slope bands        | Warm tint         | Presence/absence         |
+| Used band          | Headroom color    | Solid fill pattern       |
+| 7d-constrained     | Slate blue        | Hatched pattern          |
+| True waste         | Light/transparent | Empty/outline pattern    |
+| Gap regions        | Grey              | Hatched pattern + label  |
+
 ## Architecture Validation Results
 
 ### Coherence Validation ✅
 
 **Decision Compatibility:**
-All technology choices are compatible. Swift 5.9+ / SwiftUI / macOS 14 / @Observable / async-await / URLSession / Codable — standard Apple stack with no version conflicts or dependency issues. Zero external dependencies eliminates compatibility risk entirely.
+All technology choices are compatible. Swift 5.9+ / SwiftUI / macOS 14 / @Observable / async-await / URLSession / Codable / SQLite — standard Apple stack with no version conflicts or dependency issues. Phase 3 adds SQLite (bundled with macOS) as the only new framework dependency.
 
 **Pattern Consistency:**
-Naming follows Apple API Design Guidelines throughout. Layer-based folder structure matches MVVM service layer pattern. Error handling (async throws → AppError → connectionStatus) is consistent end to end. Logging categories map 1:1 to service components.
+Naming follows Apple API Design Guidelines throughout. Layer-based folder structure matches MVVM service layer pattern. Error handling (async throws → AppError → connectionStatus) is consistent end to end. Logging categories map 1:1 to service components. Phase 3 services follow the same protocol-based pattern established in Phase 1.
 
 **Structure Alignment:**
-Every architectural component has a defined file location. Boundaries are enforced by which component imports which framework (only KeychainService imports Security, only APIClient uses URLSession for external calls, only NotificationService imports UserNotifications). Test structure mirrors source structure.
+Every architectural component has a defined file location. Boundaries are enforced by which component imports which framework (only KeychainService imports Security, only APIClient uses URLSession for external calls, only NotificationService imports UserNotifications, only DatabaseManager imports SQLite). Test structure mirrors source structure.
 
 ### Requirements Coverage Validation ✅
 
-**Functional Requirements:** All 24 FRs have traceable architectural support with specific file mappings (see Requirements to Structure Mapping section).
+**Functional Requirements:** All 45 FRs have traceable architectural support with specific file mappings:
+- FR1-FR24 (Phase 1): See "Requirements to Structure Mapping" section
+- FR25-FR32 (Phase 2): See "Phase 2 Requirements to Structure Mapping" section
+- FR33-FR45 (Phase 3): See "Phase 3 Requirements to Structure Mapping" section
 
 **Non-Functional Requirements:** All 13 NFRs are addressed architecturally.
 
-**NFR Coverage:** All 13 NFRs aligned between PRD and architecture. NFR7 specifies fresh Keychain read each poll cycle (no token caching). NFR8 correctly references `api.anthropic.com` and `platform.claude.com`.
+**NFR Coverage:** All 13 NFRs aligned between PRD and architecture. NFR7 specifies fresh Keychain read each poll cycle (no token caching). NFR8 correctly references `api.anthropic.com` and `platform.claude.com`. Phase 3 persistent storage (SQLite) does not violate NFR6 — credentials are never written to the database, only usage metrics.
 
 ### Implementation Readiness Validation ✅
 
-**Decision Completeness:** 10 architectural decisions documented with rationale. Technology versions specified. All critical choices made.
+**Decision Completeness:** 
+- Phase 1: 10 core architectural decisions documented
+- Phase 2: 6 additional decisions (settings, CI/CD, update checks)
+- Phase 3: 8 additional decisions (SQLite, rollups, slope, analytics window)
+All with rationale. Technology versions specified. All critical choices made.
 
-**Structure Completeness:** Every source file named and placed. Directory structure is complete and specific, not generic.
+**Structure Completeness:** Every source file named and placed across all phases. Directory structure is complete and specific, not generic. Phase 3 adds 7 new model files, 7 new service files, 7 new view files.
 
-**Pattern Completeness:** Naming, structure, state management, error handling, logging, and accessibility patterns all defined with concrete examples and anti-patterns.
+**Pattern Completeness:** Naming, structure, state management, error handling, logging, and accessibility patterns all defined with concrete examples and anti-patterns. Phase 3 adds gap rendering pattern and slope communication pattern.
 
 ### Gap Analysis Results
 
@@ -830,9 +1539,9 @@ Every architectural component has a defined file location. Boundaries are enforc
 - [x] Cross-cutting concerns mapped
 
 **✅ Architectural Decisions**
-- [x] Critical decisions documented (10 decisions)
-- [x] Technology stack fully specified (Swift/SwiftUI/macOS 14)
-- [x] Integration patterns defined (API, Keychain, Notifications)
+- [x] Critical decisions documented (Phase 1: 10, Phase 2: 6, Phase 3: 8)
+- [x] Technology stack fully specified (Swift/SwiftUI/macOS 14/SQLite)
+- [x] Integration patterns defined (API, Keychain, Notifications, SQLite)
 - [x] Performance considerations addressed (NFRs mapped)
 
 **✅ Implementation Patterns**
@@ -840,29 +1549,42 @@ Every architectural component has a defined file location. Boundaries are enforc
 - [x] Structure patterns defined (layer-based organization)
 - [x] State management patterns specified (@Observable, mutation rules)
 - [x] Error handling, logging, accessibility patterns documented
+- [x] Gap rendering pattern defined (Phase 3)
+- [x] Slope communication pattern defined (Phase 3)
 
 **✅ Project Structure**
 - [x] Complete directory structure defined (every file named)
-- [x] Component boundaries established (4 boundary types)
-- [x] Integration points mapped (data flow diagram)
-- [x] All 24 FRs mapped to specific files
+- [x] Component boundaries established (4 boundary types + SQLite boundary)
+- [x] Integration points mapped (data flow diagrams for all phases)
+- [x] All 45 FRs mapped to specific files (FR1-24 Phase 1, FR25-32 Phase 2, FR33-45 Phase 3)
 
 ### Architecture Readiness Assessment
 
-**Overall Status:** READY FOR IMPLEMENTATION
+**Overall Status:** READY FOR IMPLEMENTATION (All Phases)
 
 **Confidence Level:** High
 
 **Key Strengths:**
 - API spike eliminated the highest-risk unknown — concrete endpoint, auth headers, and response format are documented
-- Zero external dependencies — nothing to break, update, or conflict
+- Minimal external dependencies — SQLite bundled with macOS, nothing else
 - Single @Observable AppState provides clear, testable state management
-- Every FR has a traceable path to a specific file
+- Every FR (45 total) has a traceable path to a specific file
 - Patterns are prescriptive enough to prevent agent divergence without being over-engineered
+- Phase 3 data layer is well-bounded — SQLite only touched by DatabaseManager and HistoricalDataService
+- On-demand rollup strategy ensures CPU is consumed only when user expects it
+
+**Resolved Design Questions (Phase 3):**
+- Database location: `~/Library/Application Support/cc-hdrm/`
+- Rollup trigger: On-demand when analytics opens
+- Slope data source: In-memory ring buffer, bootstrapped from SQLite
+- Reset detection: Primary (resets_at shift) + fallback (utilization drop)
+- Analytics window: NSPanel, non-activating, independent from popover
+- Credit limits: Hardcoded + user override in settings
 
 **Areas for Future Enhancement:**
 - Token refresh request format needs discovery during implementation
-- Phase 2 settings storage (UserDefaults) not yet designed — deferred intentionally
+- Slope threshold tuning (% per minute) needs validation with real usage data
+- Historical API research — if Anthropic exposes endpoint, could backfill gaps
 
 ### Implementation Handoff
 
@@ -871,11 +1593,30 @@ Every architectural component has a defined file location. Boundaries are enforc
 - Use implementation patterns consistently across all components
 - Respect project structure and boundaries
 - Refer to this document for all architectural questions
+- Phase 3 components should follow the same protocol-based testing pattern as Phase 1
 
-**First Implementation Priority:**
+**Phase 1 Implementation Priority:**
 1. Create Xcode project with macOS 14 target, LSUIElement=true, Keychain entitlement
 2. Implement HeadroomState enum and AppError enum (shared types first)
 3. Implement KeychainService — validate that credentials can be read
 4. Implement APIClient — validate that usage data can be fetched
 5. Wire up AppState + PollingEngine — prove the core pipeline works
 6. Build views on top of working data pipeline
+
+**Phase 2 Implementation Priority:**
+1. PreferencesManager + SettingsView
+2. UpdateCheckService
+3. Launch at login (SMAppService)
+4. CI/CD workflows
+
+**Phase 3 Implementation Priority:**
+1. DatabaseManager + SQLite schema — foundation for all Phase 3 features
+2. HistoricalDataService — persist polls, implement rollup logic
+3. SlopeLevel enum + SlopeCalculationService — enables menu bar/popover modifications
+4. Modify MenuBarTextRenderer + HeadroomRingGauge — add slope indicators
+5. Sparkline component + PopoverView modification
+6. AnalyticsWindow + AnalyticsView — full analytics experience
+7. UsageChart — step-area and bar chart modes
+8. HeadroomAnalysisService + HeadroomBreakdownBar — waste categorization
+9. RateLimitTier with credit limits + settings override
+10. Gap rendering across all chart components

--- a/_bmad-output/planning-artifacts/brainstorming-phase3-expansion-2026-02-03.md
+++ b/_bmad-output/planning-artifacts/brainstorming-phase3-expansion-2026-02-03.md
@@ -1,0 +1,209 @@
+# Brainstorming Session: Phase 3 Expansion Features
+
+**Date:** 2026-02-03
+**Participants:** Boss, Mary (Business Analyst)
+**Project:** cc-hdrm
+**Focus:** Phase 3 features — historical usage tracking, underutilised headroom analysis, and usage slope indicator
+
+---
+
+## Context
+
+cc-hdrm Phases 1 and 2 are fully implemented. The PRD defines Phase 3 as: Sonnet-specific usage breakdown, usage graphs, limit prediction, Linux tray support, and extra usage/spending tracking. This session explored three of those features in depth, refining the original "limit prediction" concept into a simpler slope indicator based on design analysis.
+
+### Key Discovery: Data Sources
+
+Investigation of Claude Code's `/stats` feature revealed:
+
+- **Claude Code stores stats locally** in `~/.claude/stats-cache.json` — daily activity, tokens per model, session data, hour-of-day heatmap data
+- This data is **client-specific** — it only tracks Claude Code sessions, not OpenCode or other clients
+- Therefore, cc-hdrm **cannot rely on Claude Code's local stats** for users of alternative clients
+- The Anthropic usage API (`api.anthropic.com/api/oauth/usage`) is **client-agnostic** — it reports account-level utilization regardless of which client consumed the tokens
+- **cc-hdrm must build its own time-series** by persisting poll results
+
+### Research Task Identified
+
+Investigate whether Anthropic exposes a **historical usage API endpoint**. They clearly have historical data server-side (Claude Code's `/stats` shows tokens per day). If such an endpoint exists, it would fill gaps from periods when cc-hdrm wasn't running.
+
+---
+
+## Feature 1: Historical Usage Tracking
+
+### Problem
+
+cc-hdrm currently polls the usage API every 30-60 seconds but discards the data after display. Users have no visibility into usage patterns over time.
+
+### Proposed Solution
+
+Persist each poll snapshot to build a local time-series database.
+
+### Storage Decision: SQLite
+
+- Year-scale retention at poll frequency generates ~525K records/year (~15-20 MB raw)
+- SQLite provides efficient querying for arbitrary time ranges and aggregation
+- Minimal dependency for a native macOS app (SQLite is bundled with macOS)
+
+### Tiered Rollup Strategy
+
+| Data Age   | Resolution          | Purpose                            |
+| ---------- | ------------------- | ---------------------------------- |
+| < 24 hours | Per-poll (~60s)     | Real-time detail, recent debugging |
+| 1-7 days   | 5-minute averages   | Short-term pattern visibility      |
+| 7-30 days  | Hourly averages     | Weekly pattern analysis            |
+| 30+ days   | Daily summary       | Long-term trends, seasonal patterns|
+
+Daily summary record includes: average utilization, peak utilization, minimum utilization, and calculated wasted headroom percentage.
+
+### Retention Period
+
+- **Configurable** via settings, default 1 year
+- At daily rollup granularity, a year is just 365 records — trivial storage
+- Enables year-scale pattern analysis: "I consistently underutilise on weekends," "February was my heaviest month"
+
+### Gap Handling
+
+**Problem:** cc-hdrm may not be running at all times. Usage can occur from other devices or while the machine is asleep. Gaps in the time-series are inevitable.
+
+**Approach:**
+1. **Accept gaps honestly** — render missing periods as a distinct visual state (hatched/grey regions). Never interpolate. The chart says "I don't know what happened here" rather than presenting fabricated data.
+2. **Infer reset boundaries** — if between two polls the `resets_at` timestamp shifted forward and utilization dropped, a reset occurred somewhere in the gap. Log this as a detected event for the headroom analysis.
+3. **Server-side history** (future/contingent) — if a historical API is discovered, use it to backfill gaps.
+
+### Visualization
+
+**Option C selected: sparkline in popover + full analytics view**
+
+- **Popover sparkline:** last 24 hours of 5h utilization, inline below the existing gauges. Gaps shown as breaks in the line.
+- **Analytics view:** separate window accessible from popover. Full history, zoomable, with multiple overlays. Supports all retention periods.
+
+### Data Captured Per Poll
+
+```
+{ timestamp, 5h_utilization, 5h_resets_at, 7d_utilization, 7d_resets_at }
+```
+
+Both windows captured together — essential for the headroom analysis.
+
+---
+
+## Feature 2: Underutilised Headroom Analysis
+
+### Core Insight
+
+The 5-hour and 7-day limits form a **nested constraint system**. The weekly limit prevents exploitation of the 5h rolling window. Headroom analysis must factor both constraints simultaneously.
+
+### Effective Headroom
+
+Effective headroom is NOT simply `100% - five_hour_utilization`. It must account for the 7-day constraint:
+
+**Effective headroom = min(5h remaining capacity, 7d remaining capacity)**
+
+A user at 10% of their 5h window but 92% of their 7d window has very little real headroom — pushing the 5h window would blow through the weekly limit.
+
+### Three Waste Categories
+
+| Category           | Definition                                                         | User Insight                                                 |
+| ------------------ | ------------------------------------------------------------------ | ------------------------------------------------------------ |
+| **5h waste**       | 5h window reset with unused capacity; 7d had room                  | "You could have done more in that window"                    |
+| **7d-constrained** | 5h had headroom but 7d was the binding constraint                  | "You were pacing correctly — pushing harder would've hit the weekly wall" |
+| **True waste**     | Both 5h and 7d had significant remaining capacity at 5h reset      | "You genuinely left capacity unused"                         |
+
+The **7d-constrained** category is explicitly **not waste** — it's smart pacing. The visualization must distinguish this to avoid misleading users into thinking they should push harder when the weekly limit would stop them.
+
+### Visualization: Three-Band Stacked Chart
+
+```
+100% |████████████████████████████████████████|
+     |         true available                 | <- what you could have used
+     |░░░░░░ 7d-constrained ░░░░░░░░░░░░░░░░░| <- couldn't safely use (not waste)
+     |▓▓▓▓▓▓ actual usage ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓|
+  0% |________________________________________|
+      Mon    Tue    Wed    Thu    Fri    Sat
+```
+
+Three bands:
+- **Used** (solid) — actual utilization
+- **7d-constrained** (hatched/muted) — headroom blocked by weekly limit
+- **True available** (empty/light) — capacity that was genuinely available but not used
+
+Calculation happens at **render time**, not storage time, since the relationship between the two limits depends on the time horizon being analyzed.
+
+---
+
+## Feature 3: Usage Slope Indicator (replaces Limit Prediction)
+
+### Why Slope Instead of Prediction
+
+The original Phase 3 item was "limit prediction based on usage slope." Through analysis, we determined that explicit time-to-exhaustion predictions have significant trust problems:
+
+- Usage patterns are **bursty**, not linear — predictions would whipsaw ("12 minutes... now 3 hours... now 8 minutes")
+- False precision erodes trust and trains users to ignore the feature
+- cc-hdrm's design philosophy is **show truthful data, let the user decide**
+
+A discrete slope indicator communicates the essential signal — **how fast am I burning?** — without pretending to know the future.
+
+### Slope Levels
+
+| Indicator    | Visual | Meaning                                    | Typical Scenario                               |
+| ------------ | ------ | ------------------------------------------ | ---------------------------------------------- |
+| **Cooling**  | ↘      | Utilization decreasing                     | Rolling window moving past older high-usage     |
+| **Flat**     | →      | No meaningful change                       | Idle, between sessions                          |
+| **Rising**   | ↗      | Moderate consumption rate                  | One active session, normal pace                 |
+| **Steep**    | ⬆      | Heavy consumption rate                     | Multiple sessions or intense conversation       |
+
+### Calculation
+
+- Sample last 10-15 minutes of poll data
+- Compute average rate of change (% per minute)
+- Map to discrete levels:
+
+| Rate (% / min) | Level   |
+| --------------- | ------- |
+| < -0.5          | Cooling |
+| -0.5 to 0.3     | Flat    |
+| 0.3 to 1.5      | Rising  |
+| > 1.5           | Steep   |
+
+Threshold values will need tuning with real usage data.
+
+### Where It Appears
+
+- **Menu bar:** inline next to utilization number — `78% ↗` — minimal UI change, significant information gain
+- **Popover:** both 5h and 7d gauges get their own slope indicator
+- **Historical analytics:** slope rendered over time shows periods of steep vs flat usage, overlaid with headroom bands
+
+### Connection to Headroom Analysis
+
+Slope + headroom together tells the full story:
+- "Every afternoon you go steep for 2 hours, then flat"
+- "You went steep on Monday and it constrained your whole week"
+- Steep slope + high 7d utilization = actionable warning signal without needing a countdown timer
+
+---
+
+## Features Not Explored (Remaining Phase 3)
+
+The following Phase 3 items were not discussed in this session and remain for future brainstorming:
+
+- **Sonnet-specific usage breakdown** — the API returns `seven_day_sonnet` data
+- **Linux tray support** — cross-platform expansion
+- **Extra usage / spending tracking** — the API returns `extra_usage` with spending data
+
+---
+
+## Recommended Next Steps
+
+1. **Technical research spike** — investigate whether Anthropic has a historical usage API endpoint
+2. **Update PRD** — add detailed functional requirements for these three features (FR33+)
+3. **Update Architecture** — SQLite integration, rollup engine design, analytics view architecture
+4. **Update UX Design** — sparkline, three-band chart, slope indicators, analytics window
+5. **Create new epics and stories** for Phase 3 implementation
+
+### Suggested Workflow Path
+
+Run in fresh context windows:
+- `/bmad-bmm-prd` — update PRD with Phase 3 requirements
+- `/bmad-bmm-create-ux-design` — design the new visualizations
+- `/bmad-bmm-create-architecture` — address SQLite, rollup engine, analytics view
+- `/bmad-bmm-create-epics-and-stories` — break into implementable stories
+- `/bmad-bmm-check-implementation-readiness` — verify alignment before development

--- a/_bmad-output/planning-artifacts/ux-design-specification-phase3.md
+++ b/_bmad-output/planning-artifacts/ux-design-specification-phase3.md
@@ -1,0 +1,700 @@
+---
+phase: 3
+inputDocuments:
+  - _bmad-output/planning-artifacts/prd.md
+  - _bmad-output/planning-artifacts/ux-design-specification.md
+  - _bmad-output/planning-artifacts/brainstorming-phase3-expansion-2026-02-03.md
+projectName: cc-hdrm
+date: 2026-02-03
+author: Boss
+---
+
+# UX Design Specification: Phase 3 Expansion
+
+**Author:** Boss
+**Date:** 2026-02-03
+
+---
+
+## Executive Summary
+
+Phase 3 extends cc-hdrm from a real-time fuel gauge into a historical analytics platform. Three interconnected features give Alex visibility not just into *where he stands now*, but *how he got here* and *how fast he's moving*:
+
+1. **Historical Usage Tracking** — Persistent storage of poll data, 24h sparkline in popover, full analytics window
+2. **Underutilised Headroom Analysis** — Three-band breakdown showing used capacity, 7d-constrained capacity, and true waste
+3. **Usage Slope Indicator** — Discrete burn rate arrows in menu bar and popover
+
+These features preserve cc-hdrm's core identity as invisible infrastructure while adding depth for users who want to understand their usage patterns.
+
+### Design Principles Carried Forward
+
+From the Phase 1 UX spec, these principles remain sacred:
+
+- **Peripheral first** — The menu bar glance is still the primary interface
+- **Silent until relevant** — New features escalate only when they add value
+- **Invisible infrastructure** — The analytics window is a tool you summon, not a presence you manage
+- **Never lose a warning** — Historical data ensures patterns are never silently lost
+
+### New Principle for Phase 3
+
+- **Honest data, no predictions** — Show truthful historical data and current burn rate. Never pretend to predict the future.
+
+---
+
+## Feature 1: Usage Slope Indicator
+
+### Problem
+
+Alex knows *where* he stands (78% utilization) but not *how fast* he's burning capacity. Is this a steady cruise or a steep climb toward the wall?
+
+### Solution
+
+A discrete 4-level slope indicator showing burn rate, displayed contextually in the menu bar and always in the popover.
+
+### Slope Levels
+
+| Level       | Arrow | Meaning                  | Typical Scenario                          |
+| ----------- | ----- | ------------------------ | ----------------------------------------- |
+| **Cooling** | ↘     | Utilization decreasing   | Rolling window moving past older usage    |
+| **Flat**    | →     | No meaningful change     | Idle, between sessions                    |
+| **Rising**  | ↗     | Moderate consumption     | One active session, normal pace           |
+| **Steep**   | ⬆     | Heavy consumption        | Multiple sessions or intense conversation |
+
+### Calculation
+
+- Sample last 10-15 minutes of poll data
+- Compute average rate of change (% per minute)
+- Map to discrete levels:
+
+| Rate (% / min) | Level   |
+| -------------- | ------- |
+| < -0.5         | Cooling |
+| -0.5 to 0.3    | Flat    |
+| 0.3 to 1.5     | Rising  |
+| > 1.5          | Steep   |
+
+Threshold values will require tuning with real usage data.
+
+### Menu Bar Display: Escalation-Only
+
+**Design decision:** The slope arrow appears in the menu bar **only** at Rising (↗) and Steep (⬆). At Flat and Cooling, it's hidden.
+
+**Rationale:** This preserves the compact footprint principle from Phase 1. During the 80% of time when things are calm, the menu bar stays minimal. The arrow earns its pixels only when the burn rate is actionable information.
+
+| State                    | Menu Bar Display | Width     |
+| ------------------------ | ---------------- | --------- |
+| Normal, Flat/Cooling     | `✳ 83%`          | ~5 chars  |
+| Normal, Rising           | `✳ 78% ↗`        | ~7 chars  |
+| Normal, Steep            | `✳ 65% ⬆`        | ~7 chars  |
+| Warning, Rising          | `✳ 17% ↗`        | ~7 chars  |
+| Exhausted, any slope     | `✳ ↻ 12m`        | ~6 chars  |
+| Disconnected             | `✳ —`            | ~3 chars  |
+
+### Popover Display: Always Visible
+
+Both gauges in the popover always show their slope indicator, regardless of level:
+
+```
+┌──────────────────┐
+│    ◯ 5h gauge    │
+│     78% ↗        │  ← slope always visible
+│  resets in 1h 12m│
+│  at 5:17 PM      │
+├──────────────────┤
+│    ◯ 7d gauge    │
+│     42% →        │  ← even flat is shown
+│  resets in 2d 1h │
+│  at Mon 7:05 PM  │
+└──────────────────┘
+```
+
+### Accessibility
+
+- VoiceOver announces slope as part of gauge reading: "5-hour headroom: 78 percent, rising"
+- Slope is never color-only — the arrow shape conveys meaning independently
+
+---
+
+## Feature 2: Historical Usage Tracking
+
+### Problem
+
+cc-hdrm currently discards poll data after display. Alex has no visibility into usage patterns over time.
+
+### Solution
+
+Persist each poll snapshot to SQLite, display a 24h sparkline in the popover, and provide a full analytics window for deep exploration.
+
+### Data Storage
+
+**Per-poll record:**
+```
+{ timestamp, 5h_utilization, 5h_resets_at, 7d_utilization, 7d_resets_at }
+```
+
+**Tiered rollup strategy:**
+
+| Data Age   | Resolution        | Purpose                             |
+| ---------- | ----------------- | ----------------------------------- |
+| < 24 hours | Per-poll (~60s)   | Real-time detail, recent debugging  |
+| 1-7 days   | 5-minute averages | Short-term pattern visibility       |
+| 7-30 days  | Hourly averages   | Weekly pattern analysis             |
+| 30+ days   | Daily summary     | Long-term trends, seasonal patterns |
+
+Daily summary includes: average utilization, peak utilization, minimum utilization, and calculated waste percentage.
+
+**Retention:** Configurable via settings, default 1 year.
+
+### The Sawtooth Data Shape
+
+Utilization data has a distinctive pattern that the visualization must honor:
+
+- **Monotonically increasing** within each window — utilization only goes up as Alex uses Claude
+- **Drops to 0%** at reset boundaries — the window clears completely
+- **Never decreases mid-window** — you can't un-use tokens
+
+This creates a sawtooth pattern:
+
+```
+100%│
+    │                    │
+    │               ▄▄▄▄▄│
+    │          ▄▄▄▄▀     │    ▄▄
+    │     ▄▄▄▀▀          │▄▄▄▀
+    │▄▄▄▀▀               │
+  0%│────────────────────┴────────
+         5h window        reset
+```
+
+### Popover Sparkline
+
+A compact 24-hour sparkline appears below the gauges, showing the shape of recent 5h utilization.
+
+```
+┌──────────────────┐
+│    ◯ 5h gauge    │
+│     78% ↗        │
+│  resets in 1h 12m│
+│  at 5:17 PM      │
+├──────────────────┤
+│    ◯ 7d gauge    │
+│     42% →        │
+│  resets in 2d 1h │
+│  at Mon 7:05 PM  │
+├──────────────────┤
+│  24h ▁▂▃▅▇│▁▂▄▅  │  ← sparkline (5h only)
+├──────────────────┤
+│ Pro │ 12s ago │ ⚙ │
+└──────────────────┘
+```
+
+**Sparkline design:**
+- Shows 5h utilization only (7d moves too slowly for a 24h sparkline to be meaningful)
+- Step-area style honoring the sawtooth shape
+- Reset boundaries visible as vertical drops to baseline
+- Gaps (cc-hdrm not running) rendered as breaks in the line — never interpolated
+- No axis labels — the shape is the story
+
+**Sparkline as analytics launcher:**
+- The sparkline is a button
+- Click to open the analytics window
+- If analytics window is already open, click brings it to front
+- Subtle hover state indicates clickability
+
+---
+
+## Feature 3: The Analytics Window
+
+### Identity & Behavior
+
+The analytics window is cc-hdrm's first real window. This is a significant expansion, handled carefully to preserve the app's identity as invisible infrastructure.
+
+**Mental model:** The analytics window is a detachable instrument panel. The menu bar is the fuel gauge you glance at while driving. The popover is the dashboard at a red light. The analytics window is the mechanic's diagnostic screen — deliberate, occasional, deep.
+
+**Window type:** NSPanel (utility panel)
+- No dock icon appears
+- No Cmd+Tab entry
+- Floats above regular windows, below full-screen apps
+- Closes via close button or Escape key
+
+**Recall mechanism:**
+- Sparkline in popover acts as toggle: click to open, click to bring to front
+- When analytics window is open, sparkline shows subtle indicator (dot or highlight)
+- Window remembers size and position between sessions
+
+**Default size:** ~600×500px, resizable
+
+### Layout Structure
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Usage Analytics                                    ✕   │
+├─────────────────────────────────────────────────────────┤
+│                                                         │
+│  [24h]  [7d]  [30d]  [All]          5h ● │ 7d ○        │
+│                                                         │
+│  100%│          │                                       │
+│      │     ▄▄▄▄▄│                                       │
+│      │▄▄▄▄▀    ││    ▄▄▄                               │
+│      │▀        ││▄▄▄▀                                   │
+│    0%│─────────┴┴────────                               │
+│      8am   12pm   4pm   8pm   12am  4am   now          │
+│                                                         │
+├─────────────────────────────────────────────────────────┤
+│  Headroom Breakdown (selected period)                   │
+│  ┌─────────────────────────────────────────────────┐    │
+│  │▓▓▓▓▓▓▓▓▓▓▓▓▓░░░░░░░░░░░                       │    │
+│  └─────────────────────────────────────────────────┘    │
+│  ▓ Used: 52%   ░ 7d-constrained: 12%   □ Waste: 36%    │
+│                                                         │
+│  Avg peak: 64%  │  Total waste: 2.1M credits           │
+│                                                         │
+└─────────────────────────────────────────────────────────┘
+```
+
+### Time Range Selector
+
+Four preset buttons: `24h`, `7d`, `30d`, `All`
+
+These map directly to the tiered rollup strategy:
+- **24h:** Per-poll data, step-area chart
+- **7d:** 5-minute rolled data, bar chart (one bar per hour)
+- **30d:** Hourly rolled data, bar chart (one bar per day)
+- **All:** Daily summaries, bar chart
+
+No custom date picker for MVP — presets cover the primary user stories.
+
+### Series Toggles
+
+`5h` and `7d` as toggleable overlays on the main chart.
+
+- Both visible by default at 24h
+- At 7d+ views, 7d becomes more interesting (slower-moving patterns)
+- Toggle state persists per time range
+
+### Main Chart: Hybrid Visualization
+
+**24h view — Step Area Chart:**
+- Honors the sawtooth shape: steps only go UP within windows
+- Reset boundaries rendered as distinct vertical lines (dashed, subtle color)
+- Gaps rendered as missing segments (no interpolation)
+- Slope intensity shown via background color bands:
+  - Steep periods: subtle warm tint behind the chart
+  - Flat periods: no tint
+  - This reinforces the slope without adding visual clutter
+
+**7d+ views — Bar Chart:**
+- Each bar represents one period (hour for 7d, day for 30d/All)
+- Bar height = **peak utilization** for that period (not average)
+- Rationale: "How close did I get to the wall?" is the question that matters
+- Reset events marked with subtle indicator below affected bars
+
+**Interaction:**
+- Hover tooltip: timestamp, exact utilization %, slope at that moment
+- For bars: period range, min/avg/peak for that period
+- Scroll to zoom, drag to pan (24h view)
+
+### Legend & Information
+
+- Legend in top-right showing series colors (5h, 7d)
+- Hover info provides detailed data points
+- Gap periods labeled on hover: "No data (cc-hdrm not running)"
+
+---
+
+## Feature 4: Underutilised Headroom Analysis
+
+### The Math
+
+The 5h and 7d limits are both measured in **credits** (the internal unit reverse-engineered from API responses). This makes them directly comparable.
+
+**Credit limits by tier:**
+
+| Tier    | Credits/5h  | Credits/7d   |
+| ------- | ----------- | ------------ |
+| Pro     | 550,000     | 5,000,000    |
+| Max 5×  | 3,300,000   | 41,666,700   |
+| Max 20× | 11,000,000  | 83,333,300   |
+
+**Calculation at each 5h reset:**
+
+```
+5h_remaining_credits = (100% - 5h_peak%) × 5h_limit
+7d_remaining_credits = (100% - 7d_util%) × 7d_limit
+effective_headroom_credits = min(5h_remaining_credits, 7d_remaining_credits)
+
+true_waste_% = effective_headroom_credits / 5h_limit × 100%
+7d_constrained_% = (5h_remaining_% - true_waste_%)
+used_% = 5h_peak%
+```
+
+**Example (Max 5× user):**
+
+5h peaked at 60%, 7d was at 85%:
+- 5h remaining: 40% × 3,300,000 = 1,320,000 credits
+- 7d remaining: 15% × 41,666,700 = 6,250,005 credits
+- Effective headroom: 1,320,000 credits (5h was the constraint)
+- True waste: 40% (all unused 5h was genuinely available)
+- 7d-constrained: 0%
+
+5h peaked at 60%, 7d was at 97%:
+- 5h remaining: 1,320,000 credits
+- 7d remaining: 3% × 41,666,700 = 1,250,001 credits
+- Effective headroom: 1,250,001 credits (7d was the constraint)
+- True waste: 1,250,001 / 3,300,000 = 37.9%
+- 7d-constrained: 40% - 37.9% = 2.1%
+
+### Three-Band Visualization
+
+The headroom breakdown appears in the analytics window below the main chart.
+
+```
+100% ┌────────────────────────────────────────┐
+     │              □ True waste              │ ← genuinely unused
+     │         (both windows had room)        │
+     ├────────────────────────────────────────┤
+     │           ░ 7d-constrained             │ ← blocked by weekly limit
+     │   (would've hit weekly wall anyway)    │   (NOT waste)
+     ├────────────────────────────────────────┤
+     │               ▓ Used                   │ ← actual consumption
+     │         (peak 5h utilization)          │
+  0% └────────────────────────────────────────┘
+```
+
+**Visual encoding:**
+- **Used (▓)** — solid fill, headroom color based on peak level
+- **7d-constrained (░)** — hatched/stippled pattern, muted slate blue. Visually reads as "blocked by system" not "you messed up"
+- **True waste (□)** — light/empty, faint fill or outline only. The "could've been yours" signal
+
+**Emotional framing:**
+- True waste → "You left capacity on the table"
+- 7d-constrained → "You were right to leave this — pushing harder would've blown your week"
+
+### Summary Statistics
+
+Below the three-band bar:
+- **Avg peak:** Average of peak utilization across resets in selected period
+- **Total waste:** Sum of true waste in credits (gives absolute sense of scale)
+- **7d-constrained:** Percentage of unused capacity that was blocked by weekly limit
+
+### Display Context
+
+- **24h view:** May show only 1-2 resets. Breakdown shows aggregate for visible resets.
+- **7d+ views:** Breakdown aggregates all resets in the selected period. This is where patterns emerge: "I consistently leave 30% on the table on weekends."
+
+---
+
+## User Journeys: Phase 3
+
+### Journey 1: The Pattern Discovery
+
+**Trigger:** Alex notices he keeps running low on Thursdays. He wants to understand why.
+
+```
+1. Alex clicks the sparkline in the popover
+2. Analytics window opens, defaults to 24h view
+3. Alex clicks [7d] to see the weekly pattern
+4. The sawtooth pattern reveals: Monday steep climb, Tuesday-Wednesday moderate, Thursday hits the wall
+5. Headroom breakdown shows: minimal waste Mon-Wed (good), but Thursday's 7d-constrained band is large
+6. Insight: "I'm not wasting capacity — I'm running into my weekly limit by Thursday"
+7. Alex adjusts his weekly pacing strategy
+```
+
+**Emotional outcome:** Understanding, not frustration. The visualization distinguishes "you messed up" from "the system constrained you."
+
+### Journey 2: The Burn Rate Warning
+
+**Trigger:** Alex is heads-down coding. The menu bar shows `✳ 45% ⬆` — the steep arrow appeared.
+
+```
+1. Alex notices the ⬆ in peripheral vision
+2. Glances at menu bar: 45% with steep burn rate
+3. Clicks to expand popover: sees both gauges with slopes
+   - 5h: 45% ⬆ (steep)
+   - 7d: 78% ↗ (rising)
+4. The sparkline shows a sharp recent climb
+5. Decision: "I'm burning fast and 7d is getting tight. Let me wrap up this task and pause."
+```
+
+**Emotional outcome:** Informed pacing. The slope indicator gave early warning before color escalation.
+
+### Journey 3: The Historical Audit
+
+**Trigger:** End of month, Alex wants to understand his usage patterns.
+
+```
+1. Opens analytics window, selects [30d]
+2. Bar chart shows daily peaks across the month
+3. Pattern emerges: weekdays average 70% peak, weekends 20%
+4. Headroom breakdown: 35% true waste (mostly weekends)
+5. Insight: "I'm leaving a third of my capacity unused. I could do more weekend projects."
+```
+
+**Emotional outcome:** Awareness of habits, opportunity identification.
+
+### Journey 4: The Gap Explanation
+
+**Trigger:** Alex was on vacation for a week. Comes back, checks analytics.
+
+```
+1. Opens analytics window, selects [30d]
+2. Sees a visible gap in the chart (hatched/grey region)
+3. Hovers over gap: "No data — cc-hdrm not running (7 days)"
+4. Usage before and after the gap is visible, but no fabricated data in between
+5. Alex appreciates the honesty: "It doesn't pretend to know what happened while I was gone"
+```
+
+**Emotional outcome:** Trust in the data. The visualization admits what it doesn't know.
+
+---
+
+## Component Strategy: Phase 3
+
+### New Custom Components
+
+#### SlopeIndicator
+
+**Purpose:** Display the discrete slope arrow with appropriate styling.
+
+**Props:**
+- `slope: SlopeLevel` (`.cooling`, `.flat`, `.rising`, `.steep`)
+- `size: CGFloat` (matches adjacent text size)
+
+**Rendering:**
+- Cooling: ↘ (system secondary color)
+- Flat: → (system secondary color)
+- Rising: ↗ (headroom color)
+- Steep: ⬆ (headroom color, slightly bolder)
+
+**Accessibility:** Announces slope level ("rising", "steep", etc.)
+
+#### Sparkline
+
+**Purpose:** Compact 24h usage visualization, acts as button to launch analytics.
+
+**Props:**
+- `data: [UsageDataPoint]` (last 24h of polls)
+- `onTap: () -> Void`
+- `isAnalyticsOpen: Bool` (shows indicator dot when true)
+
+**Rendering:**
+- Step-area path honoring sawtooth shape
+- Gaps as path breaks
+- Subtle hover/press state
+- Optional indicator dot when analytics window is open
+
+**Accessibility:** "24-hour usage chart. Double-tap to open analytics."
+
+#### UsageChart
+
+**Purpose:** Main chart in analytics window, handles both step-area and bar modes.
+
+**Props:**
+- `data: [UsageDataPoint]` or `[RolledUpDataPoint]`
+- `timeRange: TimeRange` (determines chart type)
+- `visibleSeries: Set<Series>` (5h, 7d toggles)
+- `slopeBands: Bool` (show background color bands)
+
+**Rendering:**
+- 24h: Step-area chart with reset markers
+- 7d+: Bar chart with peak values
+- Slope bands as subtle background shading
+- Gap regions as hatched/grey
+- Hover tooltip with detailed info
+
+**Accessibility:** Chart data available as accessible table for VoiceOver users.
+
+#### HeadroomBreakdownBar
+
+**Purpose:** Three-band stacked horizontal bar showing used/7d-constrained/waste.
+
+**Props:**
+- `used: Double` (percentage)
+- `sevenDayConstrained: Double` (percentage)
+- `trueWaste: Double` (percentage)
+
+**Rendering:**
+- Used: solid fill, headroom color
+- 7d-constrained: hatched pattern, muted slate blue
+- True waste: light/empty fill
+
+**Accessibility:** "Headroom breakdown: 52% used, 12% constrained by weekly limit, 36% unused."
+
+#### AnalyticsWindow
+
+**Purpose:** Container for the full analytics view.
+
+**Behavior:**
+- NSPanel (utility window)
+- No dock icon, no Cmd+Tab
+- Remembers size/position
+- Closeable via button or Escape
+
+**Layout:** Time range selector, series toggles, UsageChart, HeadroomBreakdownBar, summary stats.
+
+### Modified Components
+
+#### MenuBarTextRenderer (Phase 1 component)
+
+**Modification:** Add optional slope arrow suffix.
+
+**New logic:**
+- If slope is Rising or Steep AND not exhausted/disconnected: append arrow
+- Otherwise: no arrow (same as Phase 1)
+
+#### HeadroomRingGauge (Phase 1 component)
+
+**Modification:** Add slope indicator below percentage.
+
+**New layout:**
+```
+    ◯ (ring)
+     78%
+      ↗     ← slope indicator added
+resets in...
+```
+
+#### PopoverView (Phase 1 component)
+
+**Modification:** Add sparkline section between 7d gauge and footer.
+
+---
+
+## Consistency Patterns: Phase 3
+
+### Slope Communication Pattern
+
+Slope is communicated consistently across all locations:
+
+| Location        | Flat/Cooling | Rising | Steep |
+| --------------- | ------------ | ------ | ----- |
+| Menu bar        | Hidden       | ↗      | ⬆     |
+| Popover 5h      | →/↘          | ↗      | ⬆     |
+| Popover 7d      | →/↘          | ↗      | ⬆     |
+| Analytics chart | No tint      | Tint   | Tint  |
+
+### Gap Rendering Pattern
+
+Gaps (periods when cc-hdrm wasn't running) are rendered consistently:
+
+- **Sparkline:** Break in the line
+- **24h chart:** Missing segment, no path drawn
+- **7d+ bars:** Missing bars, subtle "no data" label on hover
+- **Headroom breakdown:** Gaps excluded from calculation (only complete windows counted)
+
+**Never interpolated.** The visualization admits what it doesn't know.
+
+### Time Display Pattern
+
+All timestamps follow the Phase 1 pattern (relative + absolute):
+
+- **Chart X-axis:** Time labels appropriate to scale (hours for 24h, days for 30d)
+- **Hover tooltip:** "Mon 2:34 PM" (absolute)
+- **Reset markers:** "Reset at 4:52 PM"
+
+---
+
+## Accessibility: Phase 3
+
+### New Accessibility Requirements
+
+#### Slope Indicator
+- Arrow shape conveys meaning (not color-only)
+- VoiceOver announces level name ("rising", "steep")
+
+#### Sparkline
+- Accessible as button with label
+- Chart data available as alternative text summary
+
+#### Analytics Window
+- Full keyboard navigation
+- Time range buttons focusable
+- Chart data available as accessible table
+- Headroom breakdown announces all three values
+
+#### Charts
+- Not relying on color alone — bars have distinct patterns, lines have distinct styles
+- Hover information available via keyboard focus
+- Summary statistics provide textual alternative to visual patterns
+
+### Color Independence
+
+All Phase 3 visualizations maintain color independence:
+
+| Element            | Color Signal         | Non-Color Signal            |
+| ------------------ | -------------------- | --------------------------- |
+| Slope arrow        | Headroom color       | Arrow direction shape       |
+| Slope bands        | Warm tint            | Presence/absence of tint    |
+| Used band          | Headroom color       | Solid fill pattern          |
+| 7d-constrained     | Slate blue           | Hatched pattern             |
+| True waste         | Light/transparent    | Empty/outline pattern       |
+| Gap regions        | Grey                 | Hatched pattern + label     |
+
+---
+
+## Implementation Notes
+
+### Credit Limit Lookup
+
+cc-hdrm reads `rateLimitTier` from Keychain credentials. Map to credit limits:
+
+```swift
+enum RateLimitTier {
+    case pro           // 550K / 5h, 5M / 7d
+    case max5x         // 3.3M / 5h, 41.67M / 7d
+    case max20x        // 11M / 5h, 83.33M / 7d
+}
+```
+
+If tier is unknown or new, fall back to percentage-only display (no headroom breakdown math).
+
+### Slope Calculation Buffering
+
+Slope calculation requires 10-15 minutes of poll history. On fresh launch:
+- First ~10 minutes: slope displays as Flat (insufficient data)
+- After buffer fills: slope calculation activates
+
+### Analytics Window State
+
+- Window position/size persisted to UserDefaults
+- Time range selection persisted per session (not across launches)
+- Series toggle state persisted per time range
+
+### Data Migration
+
+Phase 3 introduces SQLite storage. On first launch after upgrade:
+- Create database schema
+- Begin collecting data going forward
+- No historical backfill (unless Anthropic historical API is discovered)
+
+---
+
+## Summary of Design Decisions
+
+| Decision                          | Choice                                             |
+| --------------------------------- | -------------------------------------------------- |
+| Slope in menu bar                 | Escalation-only (Rising/Steep visible, Flat/Cooling hidden) |
+| Sparkline data                    | 5h only                                            |
+| Sparkline interaction             | Clickable, launches/recalls analytics window       |
+| Analytics window type             | NSPanel (utility), no dock icon                    |
+| Analytics recall                  | Sparkline as toggle                                |
+| 24h chart type                    | Step-area (honors sawtooth shape)                  |
+| 7d+ chart type                    | Bar chart (peak per period)                        |
+| Slope on historical chart         | Background color bands (subtle tint)               |
+| Headroom breakdown position       | Below chart, summary for selected period           |
+| Headroom math                     | Uses actual credit limits per tier                 |
+| Gap handling                      | Honest breaks, never interpolated                  |
+
+---
+
+## Open Questions / Future Considerations
+
+1. **Historical API:** If Anthropic exposes a historical usage endpoint, cc-hdrm could backfill gaps. Research spike recommended.
+
+2. **Slope threshold tuning:** The % per minute thresholds for Rising/Steep need validation with real usage data. May need per-tier adjustment.
+
+3. **Export functionality:** Future phase could allow exporting historical data (CSV, JSON) for external analysis.
+
+4. **Notification for slope:** Should a sustained Steep slope trigger a notification? ("You're burning fast — 15 minutes at this rate will hit the wall.") Deferred to avoid prediction territory.
+
+5. **README acknowledgement:** When Phase 3 ships, add acknowledgement to README for [@she_llac](https://twitter.com/she_llac)'s reverse-engineering of Claude's credit limits ([suspiciously precise floats](https://she-llac.com/claude-limits)). Use Option C: both a dedicated Acknowledgements section AND inline reference in "How It Works" explaining the credit math.


### PR DESCRIPTION
## Summary

Complete planning documentation for Phase 3: Expansion features.

### Documents Added/Updated

| Document | Changes |
|----------|---------|
| **PRD** | Added FR33-FR45 covering historical tracking, headroom analysis, slope indicator |
| **Architecture** | Added Phase 3 section: SQLite schema, 4 new services, analytics window, data flow |
| **UX Spec (Phase 3)** | New doc: sparkline design, analytics window layout, headroom breakdown visualization |
| **Brainstorming** | New doc: Phase 3 feature exploration and decisions |
| **Epics** | Added Epics 10-15 with 28 stories covering all Phase 3 FRs |

### Phase 3 Features

1. **Historical Usage Tracking** (FR33-38)
   - SQLite persistence with tiered rollups
   - 24h sparkline in popover
   - Full analytics window

2. **Underutilised Headroom Analysis** (FR39-41)
   - Effective headroom calculation
   - Three-band waste breakdown (used / 7d-constrained / true waste)

3. **Usage Slope Indicator** (FR42-45)
   - 4-level burn rate indicator (↘→↗⬆)
   - Menu bar (escalation-only) and popover display

### Epic Summary

| Epic | Name | Stories | FRs |
|------|------|---------|-----|
| 10 | Data Persistence & Historical Storage | 5 | FR33-34 |
| 11 | Usage Slope Indicator | 5 | FR42-45 |
| 12 | 24h Sparkline & Analytics Launcher | 4 | FR35, FR37 |
| 13 | Full Analytics Window | 7 | FR36, FR37 |
| 14 | Headroom Analysis & Waste Breakdown | 5 | FR39-41 |
| 15 | Phase 3 Settings & Data Retention | 2 | FR38 |