### PR TITLE
feat: add slope indicators to popover gauges (Story 11.4)

### DIFF
--- a/_bmad-output/implementation-artifacts/11-4-popover-slope-display.md
+++ b/_bmad-output/implementation-artifacts/11-4-popover-slope-display.md
@@ -1,0 +1,530 @@
+# Story 11.4: Popover Slope Display (Always Visible)
+
+Status: done
+
+## Story
+
+As a developer using Claude Code,
+I want to see slope indicators on both gauges in the popover,
+So that I have full visibility into burn rate for both windows.
+
+## Acceptance Criteria
+
+1. **Given** the popover is open
+   **When** FiveHourGaugeSection renders for 5h window
+   **Then** a SlopeIndicator appears inside the ring, below the percentage text
+   **And** the slope level matches AppState.fiveHourSlope
+   **And** all three levels are visible in the popover (flat, rising, steep)
+
+2. **Given** the popover is open
+   **When** SevenDayGaugeSection renders for 7d window
+   **Then** a SlopeIndicator appears with AppState.sevenDaySlope
+   **And** display is consistent with the 5h gauge
+
+3. **Given** slope data is insufficient (< 10 minutes of history)
+   **When** the popover renders
+   **Then** slope displays as flat arrow as the default
+
+4. **Given** a VoiceOver user focuses a gauge
+   **When** VoiceOver reads the element
+   **Then** it announces slope as part of the gauge reading: "[window] headroom: [X] percent, [slope level], resets in..."
+
+## Tasks / Subtasks
+
+- [x] Task 1: Create SlopeIndicator component (AC: 1, 2)
+  - [x] 1.1 Create `cc-hdrm/Views/SlopeIndicator.swift`
+  - [x] 1.2 Accept `SlopeLevel` and `HeadroomState` parameters
+  - [x] 1.3 Display the arrow character from `SlopeLevel.arrow`
+  - [x] 1.4 Apply color from `SlopeLevel.color(for: headroomState)`
+  - [x] 1.5 Use `.caption` font size for consistency with gauge labels
+  - [x] 1.6 Add `.accessibilityHidden(true)` since parent gauge handles accessibility
+  - [x] 1.7 Add `#Preview` for visual iteration
+  - [x] 1.8 Run `xcodegen generate` to add new file to project
+
+- [x] Task 2: Add slope display to HeadroomRingGauge (AC: 1, 2)
+  - [x] 2.1 Add `slopeLevel: SlopeLevel? = nil` optional parameter with default
+  - [x] 2.2 Wrap center content in VStack with `spacing: 0`
+  - [x] 2.3 Display SlopeIndicator below percentage text when slope is provided
+  - [x] 2.4 Pass existing computed `headroomState` to SlopeIndicator for color context
+  - [x] 2.5 Hide slope indicator when `headroomPercentage` is nil (disconnected state)
+
+- [x] Task 3: Integrate slope into FiveHourGaugeSection (AC: 1, 3)
+  - [x] 3.1 Pass `appState.fiveHourSlope` to HeadroomRingGauge's new `slopeLevel` parameter
+
+- [x] Task 4: Integrate slope into SevenDayGaugeSection (AC: 2, 3)
+  - [x] 4.1 Pass `appState.sevenDaySlope` to HeadroomRingGauge's new `slopeLevel` parameter
+
+- [x] Task 5: Update accessibility announcements (AC: 4)
+  - [x] 5.1 Modify FiveHourGaugeSection's `combinedAccessibilityLabel` to include slope level
+  - [x] 5.2 Modify SevenDayGaugeSection's `combinedAccessibilityLabel` to include slope level
+  - [x] 5.3 Format: "5-hour headroom: X percent, [slope level], resets in..."
+
+- [x] Task 6: Write unit tests
+  - [x] 6.1 Create `cc-hdrmTests/Views/SlopeIndicatorTests.swift`
+  - [x] 6.2 Test SlopeLevel.arrow returns correct Unicode for each level
+  - [x] 6.3 Test SlopeLevel.color(for:) returns .secondary for flat, headroom color for rising/steep
+  - [x] 6.4 Test accessibility labels include slope in FiveHourGaugeSection (create AppState, set slope, verify label string contains slope)
+  - [x] 6.5 Test accessibility labels include slope in SevenDayGaugeSection
+  - [x] 6.6 Run `xcodegen generate` if creating new test file
+
+- [x] Task 7: Build verification and regression check
+  - [x] 7.1 Run `xcodebuild -scheme cc-hdrm -destination 'platform=macOS' build`
+  - [x] 7.2 Run full test suite (currently 521+ tests)
+  - [x] 7.3 Manually verify popover displays slope arrows for both gauges
+
+## Dev Notes
+
+### CRITICAL: Slope is Always Visible in Popover (When Connected)
+
+Unlike the menu bar (which only shows slope for rising/steep), the popover **always** displays the slope indicator for both gauges when connected. This includes showing the flat arrow when slope is .flat.
+
+**Exception:** When disconnected (headroomPercentage is nil), the slope indicator is hidden. Showing a slope arrow when there's no usage data is misleading.
+
+### CRITICAL: This Story Creates SlopeIndicator
+
+Story 11.5 in the epics file is titled "SlopeIndicator Component" but describes making it reusable. **This story (11.4) creates the initial SlopeIndicator.** Story 11.5 should be considered satisfied by this implementation or re-scoped to any additional enhancements. The dev agent should mark 11.5 as done or cancelled after completing 11.4.
+
+### CRITICAL: Accessibility - Avoid Double Announcements
+
+SlopeIndicator uses `.accessibilityHidden(true)` because the parent gauge sections use `.accessibilityElement(children: .ignore)` with a combined label. The slope is announced via the gauge's `combinedAccessibilityLabel`, NOT via SlopeIndicator's own accessibility. This prevents VoiceOver from reading the slope twice.
+
+### Implementation: SlopeIndicator Component
+
+```swift
+// cc-hdrm/Views/SlopeIndicator.swift
+import SwiftUI
+
+/// Displays a slope level arrow with appropriate styling.
+/// Used in popover gauges to show burn rate.
+/// Note: Uses accessibilityHidden since parent gauge handles accessibility.
+struct SlopeIndicator: View {
+    let slopeLevel: SlopeLevel
+    let headroomState: HeadroomState
+    
+    var body: some View {
+        Text(slopeLevel.arrow)
+            .font(.caption)
+            .foregroundStyle(slopeLevel.color(for: headroomState))
+            .accessibilityHidden(true)  // Parent gauge provides combined label
+    }
+}
+
+#Preview("Flat - Normal") {
+    SlopeIndicator(slopeLevel: .flat, headroomState: .normal)
+}
+
+#Preview("Rising - Warning") {
+    SlopeIndicator(slopeLevel: .rising, headroomState: .warning)
+}
+
+#Preview("Steep - Critical") {
+    SlopeIndicator(slopeLevel: .steep, headroomState: .critical)
+}
+```
+
+### Implementation: HeadroomRingGauge Modification (Complete)
+
+```swift
+// cc-hdrm/Views/HeadroomRingGauge.swift
+import SwiftUI
+
+struct HeadroomRingGauge: View {
+    let headroomPercentage: Double?
+    let windowLabel: String
+    let ringSize: CGFloat
+    let strokeWidth: CGFloat
+    let slopeLevel: SlopeLevel?  // NEW: Optional slope, defaults to nil
+    
+    // Default initializer for backward compatibility
+    init(
+        headroomPercentage: Double?,
+        windowLabel: String,
+        ringSize: CGFloat,
+        strokeWidth: CGFloat,
+        slopeLevel: SlopeLevel? = nil  // Default nil preserves existing behavior
+    ) {
+        self.headroomPercentage = headroomPercentage
+        self.windowLabel = windowLabel
+        self.ringSize = ringSize
+        self.strokeWidth = strokeWidth
+        self.slopeLevel = slopeLevel
+    }
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    private var headroomState: HeadroomState {
+        guard let headroomPercentage else { return .disconnected }
+        return HeadroomState(from: 100.0 - headroomPercentage)
+    }
+
+    private var fillAmount: CGFloat {
+        max(0, (headroomPercentage ?? 0)) / 100.0
+    }
+
+    private var fillColor: Color {
+        headroomState.swiftUIColor
+    }
+
+    private var centerText: String {
+        guard let headroomPercentage else { return "\u{2014}" }
+        return "\(Int(max(0, headroomPercentage)))%"
+    }
+
+    private var accessibilityDescription: String {
+        guard let headroomPercentage else {
+            return "\(windowLabel) headroom: unavailable"
+        }
+        return "\(windowLabel) headroom: \(Int(max(0, headroomPercentage))) percent"
+    }
+
+    var body: some View {
+        ZStack {
+            // Track (full ring, tertiary color)
+            Circle()
+                .stroke(
+                    Color.secondary.opacity(0.3),
+                    style: StrokeStyle(lineWidth: strokeWidth, lineCap: .round)
+                )
+
+            // Fill (partial ring, headroom color)
+            Circle()
+                .trim(from: 0, to: fillAmount)
+                .stroke(
+                    fillColor,
+                    style: StrokeStyle(lineWidth: strokeWidth, lineCap: .round)
+                )
+                .rotationEffect(.degrees(-90))
+                .animation(
+                    reduceMotion ? .none : .easeInOut(duration: 0.5),
+                    value: fillAmount
+                )
+
+            // Center content: percentage + optional slope
+            VStack(spacing: 0) {
+                Text(centerText)
+                    .font(.system(.body, weight: .bold))
+                    .foregroundStyle(fillColor)
+                
+                // Slope indicator: shown only when slope provided AND connected
+                if let slope = slopeLevel, headroomPercentage != nil {
+                    SlopeIndicator(slopeLevel: slope, headroomState: headroomState)
+                }
+            }
+        }
+        .frame(width: ringSize, height: ringSize)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityDescription)
+        .accessibilityValue(
+            headroomPercentage.map { "\(Int(max(0, $0))) percent" } ?? ""
+        )
+    }
+}
+```
+
+### Implementation: FiveHourGaugeSection Integration
+
+```swift
+// cc-hdrm/Views/FiveHourGaugeSection.swift - Add slope parameter
+HeadroomRingGauge(
+    headroomPercentage: headroom,
+    windowLabel: "5h",
+    ringSize: 96,
+    strokeWidth: 7,
+    slopeLevel: appState.fiveHourSlope  // NEW
+)
+
+// Update combinedAccessibilityLabel to include slope
+private var combinedAccessibilityLabel: String {
+    guard let headroom else {
+        return "5-hour headroom: unavailable"
+    }
+    var label = "5-hour headroom: \(Int(max(0, headroom))) percent, \(appState.fiveHourSlope.accessibilityLabel)"
+    if let resetsAt = appState.fiveHour?.resetsAt {
+        label += ", resets in \(resetsAt.countdownString()), \(resetsAt.absoluteTimeString())"
+    }
+    return label
+}
+```
+
+### Implementation: SevenDayGaugeSection Integration
+
+```swift
+// cc-hdrm/Views/SevenDayGaugeSection.swift - Add slope parameter
+HeadroomRingGauge(
+    headroomPercentage: headroom,
+    windowLabel: "7d",
+    ringSize: 56,
+    strokeWidth: 4,
+    slopeLevel: appState.sevenDaySlope  // NEW
+)
+
+// Update combinedAccessibilityLabel to include slope
+private var combinedAccessibilityLabel: String {
+    guard let headroom else {
+        return "7-day headroom: unavailable"
+    }
+    var label = "7-day headroom: \(Int(max(0, headroom))) percent, \(appState.sevenDaySlope.accessibilityLabel)"
+    if let resetsAt = appState.sevenDay?.resetsAt {
+        label += ", resets in \(resetsAt.countdownString()), \(resetsAt.absoluteTimeString())"
+    }
+    return label
+}
+```
+
+### Layout Considerations
+
+**5h ring (96px):** Ample space for percentage text (~20px) + slope arrow (~12px caption). VStack with `spacing: 0` keeps them tight.
+
+**7d ring (56px):** Tighter fit but still sufficient. The percentage text is ~16px at body size, slope arrow ~10px at caption size. Total ~26px vertical content fits within 56px diameter minus stroke width.
+
+If layout issues arise, consider:
+- Reducing slope arrow to `.caption2` font
+- Adding negative spacing: `VStack(spacing: -2)`
+
+### Project Structure Notes
+
+**New files to create:**
+```text
+cc-hdrm/Views/SlopeIndicator.swift           # Reusable slope display component
+cc-hdrmTests/Views/SlopeIndicatorTests.swift # Unit tests
+```
+
+**Files to modify:**
+```text
+cc-hdrm/Views/HeadroomRingGauge.swift        # Add slopeLevel parameter, VStack center content
+cc-hdrm/Views/FiveHourGaugeSection.swift     # Pass fiveHourSlope, update accessibility
+cc-hdrm/Views/SevenDayGaugeSection.swift     # Pass sevenDaySlope, update accessibility
+```
+
+**XcodeGen reminder:** After creating new Swift files:
+```bash
+xcodegen generate
+```
+
+### SlopeLevel Reference (from cc-hdrm/Models/SlopeLevel.swift)
+
+```swift
+enum SlopeLevel: String, Sendable, Equatable, CaseIterable {
+    case flat    // arrow: "\u{2192}" (right arrow: ->)
+    case rising  // arrow: "\u{2197}" (north-east: upper-right arrow)
+    case steep   // arrow: "\u{2B06}" (up arrow)
+    
+    var arrow: String { ... }
+    var accessibilityLabel: String { rawValue }  // "flat", "rising", "steep"
+    func color(for headroomState: HeadroomState) -> Color { ... }
+    var isActionable: Bool { ... }  // false for flat, true for rising/steep
+}
+```
+
+### AppState Slope Properties (from cc-hdrm/State/AppState.swift:48-49)
+
+```swift
+private(set) var fiveHourSlope: SlopeLevel = .flat
+private(set) var sevenDaySlope: SlopeLevel = .flat
+```
+
+Both default to `.flat`, so popover will always have a valid slope to display even before 10 minutes of data collection.
+
+### Color Context Behavior
+
+Per Story 11.2, SlopeLevel colors are context-dependent:
+- `.flat` always returns `.secondary` (muted gray)
+- `.rising` and `.steep` return the current headroom state's color
+
+This means when headroom is critical (red), a steep arrow is also red - reinforcing urgency visually.
+
+### Previous Story Intelligence
+
+**From Story 11.1:**
+- SlopeCalculationService uses 15-minute ring buffer
+- Requires 10+ minutes / 20+ entries for valid calculation
+- Returns `.flat` when insufficient data
+- AppState.updateSlopes() called by PollingEngine after each fetch
+
+**From Story 11.2:**
+- `SlopeLevel.color(for:)` returns `.secondary` for flat, headroom color for rising/steep
+- `SlopeLevel.arrow` returns Unicode arrow character
+- `SlopeLevel.accessibilityLabel` returns "flat", "rising", or "steep"
+
+**From Story 11.3:**
+- Menu bar only shows slope when `isActionable` is true (rising/steep)
+- Popover is different - always shows all three levels (when connected)
+
+### Testing Strategy
+
+```swift
+// cc-hdrmTests/Views/SlopeIndicatorTests.swift
+import Testing
+import SwiftUI
+@testable import cc_hdrm
+
+@Suite("SlopeIndicator Tests")
+struct SlopeIndicatorTests {
+    
+    // MARK: - SlopeLevel.arrow Tests
+    
+    @Test("flat arrow is right arrow Unicode")
+    func flatArrowCharacter() {
+        #expect(SlopeLevel.flat.arrow == "\u{2192}")
+    }
+    
+    @Test("rising arrow is north-east Unicode")
+    func risingArrowCharacter() {
+        #expect(SlopeLevel.rising.arrow == "\u{2197}")
+    }
+    
+    @Test("steep arrow is up arrow Unicode")
+    func steepArrowCharacter() {
+        #expect(SlopeLevel.steep.arrow == "\u{2B06}")
+    }
+    
+    // MARK: - SlopeLevel.color Tests
+    
+    @Test("flat color is secondary for all headroom states")
+    func flatColorIsSecondary() {
+        for state in HeadroomState.allCases {
+            let color = SlopeLevel.flat.color(for: state)
+            #expect(color == .secondary)
+        }
+    }
+    
+    @Test("rising color matches headroom state color")
+    func risingColorMatchesHeadroom() {
+        let normalColor = SlopeLevel.rising.color(for: .normal)
+        let criticalColor = SlopeLevel.rising.color(for: .critical)
+        // Colors should differ between normal and critical states
+        #expect(normalColor != criticalColor)
+    }
+    
+    @Test("steep color matches headroom state color")
+    func steepColorMatchesHeadroom() {
+        let normalColor = SlopeLevel.steep.color(for: .normal)
+        let criticalColor = SlopeLevel.steep.color(for: .critical)
+        #expect(normalColor != criticalColor)
+    }
+    
+    // MARK: - Accessibility Label Tests
+    
+    @Test("accessibility labels are lowercase slope names")
+    func accessibilityLabels() {
+        #expect(SlopeLevel.flat.accessibilityLabel == "flat")
+        #expect(SlopeLevel.rising.accessibilityLabel == "rising")
+        #expect(SlopeLevel.steep.accessibilityLabel == "steep")
+    }
+}
+
+@Suite("Gauge Section Accessibility Tests")
+@MainActor
+struct GaugeSectionAccessibilityTests {
+    
+    @Test("5h gauge accessibility includes slope level")
+    func fiveHourAccessibilityIncludesSlope() {
+        let appState = AppState()
+        appState.updateConnectionStatus(.connected)
+        appState.updateWindows(
+            fiveHour: WindowState(utilization: 20.0, resetsAt: Date().addingTimeInterval(3600)),
+            sevenDay: nil
+        )
+        appState.updateSlopes(fiveHour: .rising, sevenDay: .flat)
+        
+        // Create section and verify accessibility label contains "rising"
+        let section = FiveHourGaugeSection(appState: appState)
+        // Note: Access combinedAccessibilityLabel via reflection or make it internal for testing
+        // The label should contain "rising" when fiveHourSlope is .rising
+    }
+    
+    @Test("7d gauge accessibility includes slope level")
+    func sevenDayAccessibilityIncludesSlope() {
+        let appState = AppState()
+        appState.updateConnectionStatus(.connected)
+        appState.updateWindows(
+            fiveHour: WindowState(utilization: 20.0, resetsAt: Date().addingTimeInterval(3600)),
+            sevenDay: WindowState(utilization: 30.0, resetsAt: Date().addingTimeInterval(86400))
+        )
+        appState.updateSlopes(fiveHour: .flat, sevenDay: .steep)
+        
+        // Verify 7d accessibility label contains "steep"
+    }
+}
+```
+
+### Edge Cases to Handle
+
+| # | Condition | Expected Behavior |
+|---|-----------|-------------------|
+| 1 | App just launched (no slope data) | Show flat arrow (AppState defaults to .flat) |
+| 2 | Less than 10 min history | Show flat arrow (SlopeCalculationService returns .flat) |
+| 3 | 5h normal, slope .flat | Show flat arrow in secondary color |
+| 4 | 5h warning, slope .rising | Show rising arrow in warning (orange) color |
+| 5 | 5h critical, slope .steep | Show steep arrow in critical (red) color |
+| 6 | 7d data unavailable (nil) | 7d section hidden entirely - slope irrelevant |
+| 7 | **Disconnected state** | **Slope hidden** - gauge shows em dash only, no slope arrow |
+
+### Backward Compatibility
+
+The `slopeLevel` parameter defaults to `nil` in the initializer:
+
+```swift
+init(..., slopeLevel: SlopeLevel? = nil)
+```
+
+This ensures any existing code that doesn't pass `slopeLevel` continues to work without modification.
+
+### References
+
+- [Source: cc-hdrm/Models/SlopeLevel.swift] - SlopeLevel enum with arrow, color, accessibilityLabel
+- [Source: cc-hdrm/State/AppState.swift:48-49] - fiveHourSlope and sevenDaySlope properties
+- [Source: cc-hdrm/Views/HeadroomRingGauge.swift] - Current gauge implementation
+- [Source: cc-hdrm/Views/FiveHourGaugeSection.swift] - 5h gauge section
+- [Source: cc-hdrm/Views/SevenDayGaugeSection.swift] - 7d gauge section
+- [Source: _bmad-output/planning-artifacts/epics.md:1234-1260] - Story 11.4 acceptance criteria
+- [Source: _bmad-output/planning-artifacts/ux-design-specification-phase3.md] - Slope display rules
+- [Source: _bmad-output/implementation-artifacts/11-2-slope-level-calculation-mapping.md] - Previous story context
+- [Source: _bmad-output/implementation-artifacts/11-3-menu-bar-slope-display.md] - Previous story context
+
+## Dev Agent Record
+
+### Agent Model Used
+
+claude-opus-4-5
+
+### Debug Log References
+
+None
+
+### Completion Notes List
+
+- Created SlopeIndicator component with `.caption` font and `.accessibilityHidden(true)`
+- Added `slopeLevel: SlopeLevel? = nil` parameter to HeadroomRingGauge with backward-compatible default
+- Wrapped gauge center content in VStack(spacing: 0) to stack percentage + slope
+- Slope indicator hidden when headroomPercentage is nil (disconnected state)
+- Updated FiveHourGaugeSection and SevenDayGaugeSection to pass slope to gauge
+- Updated accessibility labels to include slope: "X percent, [slope level], resets in..."
+- All 544 tests pass (23 new tests for Story 11.4)
+- Note: Story 11.5 "SlopeIndicator Component" can be marked done or cancelled per Dev Notes
+
+### Code Review Fixes (2026-02-04)
+
+- **H1 Fixed:** Made `combinedAccessibilityLabel` internal (was private) for `@testable import` access
+- **M1 Fixed:** Added format verification tests that check label order: percent → slope → resets
+- **M2 Fixed:** Renamed tests from "includes" to "LabelContains" to accurately reflect behavior
+- **L1 Fixed:** Consolidated 10 preview blocks into 3 using ForEach
+- **L2 Fixed:** Added disconnected accessibility tests for both gauge sections
+- All 548 tests pass (4 new review tests added)
+
+### File List
+
+**New Files:**
+- cc-hdrm/Views/SlopeIndicator.swift
+- cc-hdrmTests/Views/SlopeIndicatorTests.swift
+
+**Modified Files:**
+- cc-hdrm/Views/HeadroomRingGauge.swift (added slopeLevel parameter, VStack center content)
+- cc-hdrm/Views/FiveHourGaugeSection.swift (pass fiveHourSlope, update accessibility, made combinedAccessibilityLabel internal)
+- cc-hdrm/Views/SevenDayGaugeSection.swift (pass sevenDaySlope, update accessibility, made combinedAccessibilityLabel internal)
+
+**Review Fix Changes:**
+- cc-hdrm/Views/SlopeIndicator.swift (consolidated previews from 10 to 3)
+- cc-hdrm/Views/FiveHourGaugeSection.swift (combinedAccessibilityLabel: private → internal)
+- cc-hdrm/Views/SevenDayGaugeSection.swift (combinedAccessibilityLabel: private → internal)
+- cc-hdrmTests/Views/SlopeIndicatorTests.swift (renamed tests, added 4 new format/disconnected tests)

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -100,7 +100,7 @@ development_status:
   epic-11: in-progress
   11-1-slope-calculation-service-ring-buffer: review
   11-2-slope-level-calculation-mapping: done
-  11-3-menu-bar-slope-display: backlog
-  11-4-popover-slope-display: backlog
+  11-3-menu-bar-slope-display: review
+  11-4-popover-slope-display: done
   11-5-slope-indicator-component: backlog
   epic-11-retrospective: optional

--- a/cc-hdrm/Views/FiveHourGaugeSection.swift
+++ b/cc-hdrm/Views/FiveHourGaugeSection.swift
@@ -15,13 +15,14 @@ struct FiveHourGaugeSection: View {
         appState.fiveHour?.headroomState ?? .disconnected
     }
 
-    /// Combined VoiceOver announcement per AC #14:
-    /// "5-hour headroom: [X] percent, resets in [relative], at [absolute]"
-    private var combinedAccessibilityLabel: String {
+    /// Combined VoiceOver announcement per AC #14 + Story 11.4 AC #4:
+    /// "5-hour headroom: [X] percent, [slope level], resets in [relative], at [absolute]"
+    /// Internal (not private) to allow @testable import verification.
+    var combinedAccessibilityLabel: String {
         guard let headroom else {
             return "5-hour headroom: unavailable"
         }
-        var label = "5-hour headroom: \(Int(max(0, headroom))) percent"
+        var label = "5-hour headroom: \(Int(max(0, headroom))) percent, \(appState.fiveHourSlope.accessibilityLabel)"
         if let resetsAt = appState.fiveHour?.resetsAt {
             label += ", resets in \(resetsAt.countdownString()), \(resetsAt.absoluteTimeString())"
         }
@@ -35,12 +36,13 @@ struct FiveHourGaugeSection: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
 
-            // Ring gauge (AC #1-#5, #9, #11-#13)
+            // Ring gauge (AC #1-#5, #9, #11-#13) + slope display (Story 11.4)
             HeadroomRingGauge(
                 headroomPercentage: headroom,
                 windowLabel: "5h",
                 ringSize: 96,
-                strokeWidth: 7
+                strokeWidth: 7,
+                slopeLevel: appState.fiveHourSlope
             )
 
             // Countdown: relative + absolute (AC #7, #8, #10)

--- a/cc-hdrm/Views/HeadroomRingGauge.swift
+++ b/cc-hdrm/Views/HeadroomRingGauge.swift
@@ -12,6 +12,23 @@ struct HeadroomRingGauge: View {
     let ringSize: CGFloat
     /// Stroke width of the ring.
     let strokeWidth: CGFloat
+    /// Optional slope level to display below percentage. Defaults to `nil` for backward compatibility.
+    let slopeLevel: SlopeLevel?
+
+    /// Initializer with default nil slope for backward compatibility.
+    init(
+        headroomPercentage: Double?,
+        windowLabel: String,
+        ringSize: CGFloat,
+        strokeWidth: CGFloat,
+        slopeLevel: SlopeLevel? = nil
+    ) {
+        self.headroomPercentage = headroomPercentage
+        self.windowLabel = windowLabel
+        self.ringSize = ringSize
+        self.strokeWidth = strokeWidth
+        self.slopeLevel = slopeLevel
+    }
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
@@ -68,10 +85,17 @@ struct HeadroomRingGauge: View {
                     value: fillAmount
                 )
 
-            // Center percentage text
-            Text(centerText)
-                .font(.system(.body, weight: .bold))
-                .foregroundStyle(fillColor)
+            // Center content: percentage + optional slope
+            VStack(spacing: 0) {
+                Text(centerText)
+                    .font(.system(.body, weight: .bold))
+                    .foregroundStyle(fillColor)
+
+                // Slope indicator: shown only when slope provided AND connected
+                if let slope = slopeLevel, headroomPercentage != nil {
+                    SlopeIndicator(slopeLevel: slope, headroomState: headroomState)
+                }
+            }
         }
         .frame(width: ringSize, height: ringSize)
         .accessibilityElement(children: .ignore)

--- a/cc-hdrm/Views/SevenDayGaugeSection.swift
+++ b/cc-hdrm/Views/SevenDayGaugeSection.swift
@@ -16,13 +16,14 @@ struct SevenDayGaugeSection: View {
         appState.sevenDay?.headroomState ?? .disconnected
     }
 
-    /// Combined VoiceOver announcement (AC #7):
-    /// "7-day headroom: [X] percent, resets in [relative], at [absolute]"
-    private var combinedAccessibilityLabel: String {
+    /// Combined VoiceOver announcement (AC #7) + Story 11.4 AC #4:
+    /// "7-day headroom: [X] percent, [slope level], resets in [relative], at [absolute]"
+    /// Internal (not private) to allow @testable import verification.
+    var combinedAccessibilityLabel: String {
         guard let headroom else {
             return "7-day headroom: unavailable"
         }
-        var label = "7-day headroom: \(Int(max(0, headroom))) percent"
+        var label = "7-day headroom: \(Int(max(0, headroom))) percent, \(appState.sevenDaySlope.accessibilityLabel)"
         if let resetsAt = appState.sevenDay?.resetsAt {
             label += ", resets in \(resetsAt.countdownString()), \(resetsAt.absoluteTimeString())"
         }
@@ -38,12 +39,13 @@ struct SevenDayGaugeSection: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
 
-                // Ring gauge: 56px diameter, 4px stroke (AC #1-#2)
+                // Ring gauge: 56px diameter, 4px stroke (AC #1-#2) + slope display (Story 11.4)
                 HeadroomRingGauge(
                     headroomPercentage: headroom,
                     windowLabel: "7d",
                     ringSize: 56,
-                    strokeWidth: 4
+                    strokeWidth: 4,
+                    slopeLevel: appState.sevenDaySlope
                 )
 
                 // Countdown: relative + absolute (AC #4, #5)

--- a/cc-hdrm/Views/SlopeIndicator.swift
+++ b/cc-hdrm/Views/SlopeIndicator.swift
@@ -1,0 +1,62 @@
+import SwiftUI
+
+/// Displays a slope level arrow with appropriate styling.
+/// Used in popover gauges to show burn rate.
+///
+/// Uses `.accessibilityHidden(true)` because the parent gauge section provides
+/// a combined accessibility label that includes slope information. This prevents
+/// VoiceOver from reading the slope twice.
+struct SlopeIndicator: View {
+    /// The slope level to display (flat, rising, or steep).
+    let slopeLevel: SlopeLevel
+    /// The current headroom state, used to determine arrow color for rising/steep.
+    let headroomState: HeadroomState
+
+    var body: some View {
+        Text(slopeLevel.arrow)
+            .font(.caption)
+            .foregroundStyle(slopeLevel.color(for: headroomState))
+            .accessibilityHidden(true) // Parent gauge provides combined label
+    }
+}
+
+// MARK: - Previews
+
+#Preview("All Slopes by Headroom State") {
+    VStack(alignment: .leading, spacing: 16) {
+        ForEach(HeadroomState.allCases, id: \.self) { state in
+            HStack(spacing: 16) {
+                Text(String(describing: state).capitalized)
+                    .frame(width: 80, alignment: .leading)
+                    .font(.caption)
+                ForEach(SlopeLevel.allCases, id: \.self) { slope in
+                    VStack(spacing: 2) {
+                        SlopeIndicator(slopeLevel: slope, headroomState: state)
+                        Text(slope.rawValue)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+        }
+    }
+    .padding()
+}
+
+#Preview("In Context - Normal") {
+    HStack(spacing: 20) {
+        ForEach(SlopeLevel.allCases, id: \.self) { slope in
+            SlopeIndicator(slopeLevel: slope, headroomState: .normal)
+        }
+    }
+    .padding()
+}
+
+#Preview("In Context - Critical") {
+    HStack(spacing: 20) {
+        ForEach(SlopeLevel.allCases, id: \.self) { slope in
+            SlopeIndicator(slopeLevel: slope, headroomState: .critical)
+        }
+    }
+    .padding()
+}

--- a/cc-hdrmTests/Views/SlopeIndicatorTests.swift
+++ b/cc-hdrmTests/Views/SlopeIndicatorTests.swift
@@ -1,0 +1,424 @@
+import SwiftUI
+import Testing
+@testable import cc_hdrm
+
+/// Tests for SlopeIndicator component and related accessibility (Story 11.4).
+///
+/// Note: SlopeLevel.arrow and SlopeLevel.color(for:) tests exist in SlopeLevelTests.swift.
+/// This file tests the SlopeIndicator View component and accessibility label integration.
+
+@Suite("SlopeIndicator Component Tests")
+struct SlopeIndicatorComponentTests {
+
+    // MARK: - Component Instantiation
+
+    @Test("SlopeIndicator can be instantiated with flat slope and normal state")
+    @MainActor
+    func instantiateFlatNormal() {
+        let indicator = SlopeIndicator(slopeLevel: .flat, headroomState: .normal)
+        _ = indicator.body
+    }
+
+    @Test("SlopeIndicator can be instantiated with rising slope and warning state")
+    @MainActor
+    func instantiateRisingWarning() {
+        let indicator = SlopeIndicator(slopeLevel: .rising, headroomState: .warning)
+        _ = indicator.body
+    }
+
+    @Test("SlopeIndicator can be instantiated with steep slope and critical state")
+    @MainActor
+    func instantiateSteepCritical() {
+        let indicator = SlopeIndicator(slopeLevel: .steep, headroomState: .critical)
+        _ = indicator.body
+    }
+
+    @Test("SlopeIndicator renders for all slope and headroom combinations")
+    @MainActor
+    func allCombinations() {
+        for slope in SlopeLevel.allCases {
+            for state in HeadroomState.allCases {
+                let indicator = SlopeIndicator(slopeLevel: slope, headroomState: state)
+                _ = indicator.body
+            }
+        }
+    }
+}
+
+// MARK: - Gauge Section Accessibility Tests (Story 11.4 AC #4)
+
+@Suite("Gauge Section Slope Accessibility Tests")
+@MainActor
+struct GaugeSectionSlopeAccessibilityTests {
+
+    // MARK: - FiveHourGaugeSection Accessibility Label Verification
+
+    @Test("5h gauge combinedAccessibilityLabel contains 'flat' when slope is flat")
+    func fiveHourLabelContainsFlat() {
+        let appState = AppState()
+        appState.updateConnectionStatus(.connected)
+        appState.updateWindows(
+            fiveHour: WindowState(utilization: 20.0, resetsAt: Date().addingTimeInterval(3600)),
+            sevenDay: nil
+        )
+        appState.updateSlopes(fiveHour: .flat, sevenDay: .flat)
+
+        let section = FiveHourGaugeSection(appState: appState)
+        let label = section.combinedAccessibilityLabel
+        #expect(label.contains("flat"), "Label should contain 'flat': \(label)")
+        #expect(label.contains("80 percent"), "Label should contain headroom percentage")
+    }
+
+    @Test("5h gauge combinedAccessibilityLabel contains 'rising' when slope is rising")
+    func fiveHourLabelContainsRising() {
+        let appState = AppState()
+        appState.updateConnectionStatus(.connected)
+        appState.updateWindows(
+            fiveHour: WindowState(utilization: 50.0, resetsAt: Date().addingTimeInterval(3600)),
+            sevenDay: nil
+        )
+        appState.updateSlopes(fiveHour: .rising, sevenDay: .flat)
+
+        let section = FiveHourGaugeSection(appState: appState)
+        let label = section.combinedAccessibilityLabel
+        #expect(label.contains("rising"), "Label should contain 'rising': \(label)")
+    }
+
+    @Test("5h gauge combinedAccessibilityLabel contains 'steep' when slope is steep")
+    func fiveHourLabelContainsSteep() {
+        let appState = AppState()
+        appState.updateConnectionStatus(.connected)
+        appState.updateWindows(
+            fiveHour: WindowState(utilization: 80.0, resetsAt: Date().addingTimeInterval(3600)),
+            sevenDay: nil
+        )
+        appState.updateSlopes(fiveHour: .steep, sevenDay: .flat)
+
+        let section = FiveHourGaugeSection(appState: appState)
+        let label = section.combinedAccessibilityLabel
+        #expect(label.contains("steep"), "Label should contain 'steep': \(label)")
+    }
+
+    // MARK: - SevenDayGaugeSection Accessibility Label Verification
+
+    @Test("7d gauge combinedAccessibilityLabel contains 'flat' when slope is flat")
+    func sevenDayLabelContainsFlat() {
+        let appState = AppState()
+        appState.updateConnectionStatus(.connected)
+        appState.updateWindows(
+            fiveHour: WindowState(utilization: 20.0, resetsAt: Date().addingTimeInterval(3600)),
+            sevenDay: WindowState(utilization: 30.0, resetsAt: Date().addingTimeInterval(86400))
+        )
+        appState.updateSlopes(fiveHour: .flat, sevenDay: .flat)
+
+        let section = SevenDayGaugeSection(appState: appState)
+        let label = section.combinedAccessibilityLabel
+        #expect(label.contains("flat"), "Label should contain 'flat': \(label)")
+        #expect(label.contains("70 percent"), "Label should contain headroom percentage")
+    }
+
+    @Test("7d gauge combinedAccessibilityLabel contains 'rising' when slope is rising")
+    func sevenDayLabelContainsRising() {
+        let appState = AppState()
+        appState.updateConnectionStatus(.connected)
+        appState.updateWindows(
+            fiveHour: WindowState(utilization: 20.0, resetsAt: Date().addingTimeInterval(3600)),
+            sevenDay: WindowState(utilization: 50.0, resetsAt: Date().addingTimeInterval(86400))
+        )
+        appState.updateSlopes(fiveHour: .flat, sevenDay: .rising)
+
+        let section = SevenDayGaugeSection(appState: appState)
+        let label = section.combinedAccessibilityLabel
+        #expect(label.contains("rising"), "Label should contain 'rising': \(label)")
+    }
+
+    @Test("7d gauge combinedAccessibilityLabel contains 'steep' when slope is steep")
+    func sevenDayLabelContainsSteep() {
+        let appState = AppState()
+        appState.updateConnectionStatus(.connected)
+        appState.updateWindows(
+            fiveHour: WindowState(utilization: 20.0, resetsAt: Date().addingTimeInterval(3600)),
+            sevenDay: WindowState(utilization: 80.0, resetsAt: Date().addingTimeInterval(86400))
+        )
+        appState.updateSlopes(fiveHour: .flat, sevenDay: .steep)
+
+        let section = SevenDayGaugeSection(appState: appState)
+        let label = section.combinedAccessibilityLabel
+        #expect(label.contains("steep"), "Label should contain 'steep': \(label)")
+    }
+
+    // MARK: - Default Slope Behavior (AC #3)
+
+    @Test("slopes default to flat when no data (less than 10 min history)")
+    func defaultSlopeIsFlat() {
+        let appState = AppState()
+        // Default AppState has slopes set to .flat
+        #expect(appState.fiveHourSlope == .flat)
+        #expect(appState.sevenDaySlope == .flat)
+    }
+
+    // MARK: - Accessibility Format Verification (AC #4)
+
+    @Test("5h accessibility follows format: window, percent, slope, resets")
+    func fiveHourAccessibilityFormat() {
+        let appState = AppState()
+        appState.updateConnectionStatus(.connected)
+        appState.updateWindows(
+            fiveHour: WindowState(utilization: 25.0, resetsAt: Date().addingTimeInterval(3600)),
+            sevenDay: nil
+        )
+        appState.updateSlopes(fiveHour: .rising, sevenDay: .flat)
+
+        let section = FiveHourGaugeSection(appState: appState)
+        let label = section.combinedAccessibilityLabel
+
+        // Verify format: "5-hour headroom: [X] percent, [slope], resets in..."
+        #expect(label.hasPrefix("5-hour headroom:"), "Should start with '5-hour headroom:'")
+        #expect(label.contains("75 percent"), "Should contain headroom percentage")
+        #expect(label.contains("rising"), "Should contain slope level")
+        #expect(label.contains("resets in"), "Should contain 'resets in'")
+
+        // Verify order: percent comes before slope, slope comes before resets
+        if let percentRange = label.range(of: "percent"),
+           let slopeRange = label.range(of: "rising"),
+           let resetsRange = label.range(of: "resets") {
+            #expect(percentRange.lowerBound < slopeRange.lowerBound, "percent should come before slope")
+            #expect(slopeRange.lowerBound < resetsRange.lowerBound, "slope should come before resets")
+        }
+    }
+
+    @Test("7d accessibility follows format: window, percent, slope, resets")
+    func sevenDayAccessibilityFormat() {
+        let appState = AppState()
+        appState.updateConnectionStatus(.connected)
+        appState.updateWindows(
+            fiveHour: WindowState(utilization: 20.0, resetsAt: Date().addingTimeInterval(3600)),
+            sevenDay: WindowState(utilization: 40.0, resetsAt: Date().addingTimeInterval(86400))
+        )
+        appState.updateSlopes(fiveHour: .flat, sevenDay: .steep)
+
+        let section = SevenDayGaugeSection(appState: appState)
+        let label = section.combinedAccessibilityLabel
+
+        // Verify format: "7-day headroom: [X] percent, [slope], resets in..."
+        #expect(label.hasPrefix("7-day headroom:"), "Should start with '7-day headroom:'")
+        #expect(label.contains("60 percent"), "Should contain headroom percentage")
+        #expect(label.contains("steep"), "Should contain slope level")
+        #expect(label.contains("resets in"), "Should contain 'resets in'")
+    }
+
+    // MARK: - Disconnected State Accessibility (L2)
+
+    @Test("5h accessibility returns 'unavailable' when disconnected")
+    func fiveHourDisconnectedAccessibility() {
+        let appState = AppState()
+        // Don't set any windows - simulates disconnected state
+
+        let section = FiveHourGaugeSection(appState: appState)
+        let label = section.combinedAccessibilityLabel
+
+        #expect(label == "5-hour headroom: unavailable")
+        #expect(!label.contains("flat"), "Disconnected should not mention slope")
+        #expect(!label.contains("resets"), "Disconnected should not mention resets")
+    }
+
+    @Test("7d accessibility returns 'unavailable' when no 7d data")
+    func sevenDayDisconnectedAccessibility() {
+        let appState = AppState()
+        appState.updateConnectionStatus(.connected)
+        appState.updateWindows(
+            fiveHour: WindowState(utilization: 20.0, resetsAt: Date().addingTimeInterval(3600)),
+            sevenDay: nil  // No 7d data
+        )
+
+        let section = SevenDayGaugeSection(appState: appState)
+        let label = section.combinedAccessibilityLabel
+
+        #expect(label == "7-day headroom: unavailable")
+    }
+
+    // MARK: - FiveHourGaugeSection Renders with Slope
+
+    @Test("FiveHourGaugeSection renders with slope without crash")
+    func fiveHourSectionRendersWithSlope() {
+        let appState = AppState()
+        appState.updateConnectionStatus(.connected)
+        appState.updateWindows(
+            fiveHour: WindowState(utilization: 30.0, resetsAt: Date().addingTimeInterval(3600)),
+            sevenDay: nil
+        )
+        appState.updateSlopes(fiveHour: .rising, sevenDay: .flat)
+
+        let section = FiveHourGaugeSection(appState: appState)
+        _ = section.body
+        // No crash — slope is passed to HeadroomRingGauge
+    }
+
+    @Test("FiveHourGaugeSection renders with all slope levels")
+    func fiveHourSectionRendersAllSlopeLevels() {
+        let appState = AppState()
+        appState.updateConnectionStatus(.connected)
+        appState.updateWindows(
+            fiveHour: WindowState(utilization: 50.0, resetsAt: Date().addingTimeInterval(3600)),
+            sevenDay: nil
+        )
+
+        for slope in SlopeLevel.allCases {
+            appState.updateSlopes(fiveHour: slope, sevenDay: .flat)
+            let section = FiveHourGaugeSection(appState: appState)
+            _ = section.body
+        }
+    }
+
+    // MARK: - SevenDayGaugeSection Renders with Slope
+
+    @Test("SevenDayGaugeSection renders with slope without crash")
+    func sevenDaySectionRendersWithSlope() {
+        let appState = AppState()
+        appState.updateConnectionStatus(.connected)
+        appState.updateWindows(
+            fiveHour: WindowState(utilization: 20.0, resetsAt: Date().addingTimeInterval(3600)),
+            sevenDay: WindowState(utilization: 40.0, resetsAt: Date().addingTimeInterval(86400))
+        )
+        appState.updateSlopes(fiveHour: .flat, sevenDay: .steep)
+
+        let section = SevenDayGaugeSection(appState: appState)
+        _ = section.body
+        // No crash — slope is passed to HeadroomRingGauge
+    }
+
+    @Test("SevenDayGaugeSection renders with all slope levels")
+    func sevenDaySectionRendersAllSlopeLevels() {
+        let appState = AppState()
+        appState.updateConnectionStatus(.connected)
+        appState.updateWindows(
+            fiveHour: WindowState(utilization: 20.0, resetsAt: Date().addingTimeInterval(3600)),
+            sevenDay: WindowState(utilization: 50.0, resetsAt: Date().addingTimeInterval(86400))
+        )
+
+        for slope in SlopeLevel.allCases {
+            appState.updateSlopes(fiveHour: .flat, sevenDay: slope)
+            let section = SevenDayGaugeSection(appState: appState)
+            _ = section.body
+        }
+    }
+}
+
+// MARK: - HeadroomRingGauge Slope Tests
+
+@Suite("HeadroomRingGauge Slope Display Tests")
+struct HeadroomRingGaugeSlopeTests {
+
+    @Test("HeadroomRingGauge accepts nil slope for backward compatibility")
+    @MainActor
+    func nilSlopeBackwardCompatibility() {
+        let gauge = HeadroomRingGauge(
+            headroomPercentage: 75.0,
+            windowLabel: "5h",
+            ringSize: 96,
+            strokeWidth: 7
+            // slopeLevel not provided — uses default nil
+        )
+        _ = gauge.body
+    }
+
+    @Test("HeadroomRingGauge renders with explicit nil slope")
+    @MainActor
+    func explicitNilSlope() {
+        let gauge = HeadroomRingGauge(
+            headroomPercentage: 75.0,
+            windowLabel: "5h",
+            ringSize: 96,
+            strokeWidth: 7,
+            slopeLevel: nil
+        )
+        _ = gauge.body
+    }
+
+    @Test("HeadroomRingGauge renders with flat slope")
+    @MainActor
+    func flatSlope() {
+        let gauge = HeadroomRingGauge(
+            headroomPercentage: 75.0,
+            windowLabel: "5h",
+            ringSize: 96,
+            strokeWidth: 7,
+            slopeLevel: .flat
+        )
+        _ = gauge.body
+    }
+
+    @Test("HeadroomRingGauge renders with rising slope")
+    @MainActor
+    func risingSlope() {
+        let gauge = HeadroomRingGauge(
+            headroomPercentage: 50.0,
+            windowLabel: "5h",
+            ringSize: 96,
+            strokeWidth: 7,
+            slopeLevel: .rising
+        )
+        _ = gauge.body
+    }
+
+    @Test("HeadroomRingGauge renders with steep slope")
+    @MainActor
+    func steepSlope() {
+        let gauge = HeadroomRingGauge(
+            headroomPercentage: 10.0,
+            windowLabel: "5h",
+            ringSize: 96,
+            strokeWidth: 7,
+            slopeLevel: .steep
+        )
+        _ = gauge.body
+    }
+
+    @Test("HeadroomRingGauge hides slope when disconnected (nil headroom)")
+    @MainActor
+    func slopeHiddenWhenDisconnected() {
+        // When headroomPercentage is nil, slope should not display
+        // The component logic: if let slope = slopeLevel, headroomPercentage != nil
+        let gauge = HeadroomRingGauge(
+            headroomPercentage: nil,
+            windowLabel: "5h",
+            ringSize: 96,
+            strokeWidth: 7,
+            slopeLevel: .rising // Slope provided but shouldn't display
+        )
+        _ = gauge.body
+        // No crash — slope hidden when disconnected
+    }
+
+    @Test("HeadroomRingGauge renders for 7d size with slope")
+    @MainActor
+    func sevenDaySizeWithSlope() {
+        let gauge = HeadroomRingGauge(
+            headroomPercentage: 65.0,
+            windowLabel: "7d",
+            ringSize: 56,
+            strokeWidth: 4,
+            slopeLevel: .rising
+        )
+        _ = gauge.body
+    }
+
+    @Test("HeadroomRingGauge renders all slope levels with all headroom states")
+    @MainActor
+    func allSlopesWithAllStates() {
+        let headroomValues: [Double?] = [nil, 0, 3, 12, 30, 75]
+
+        for headroom in headroomValues {
+            for slope in SlopeLevel.allCases {
+                let gauge = HeadroomRingGauge(
+                    headroomPercentage: headroom,
+                    windowLabel: "5h",
+                    ringSize: 96,
+                    strokeWidth: 7,
+                    slopeLevel: slope
+                )
+                _ = gauge.body
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add `SlopeIndicator` component displaying slope arrows (flat/rising/steep) with context-aware coloring
- Integrate slope display into both 5-hour and 7-day gauge sections in the popover
- Update VoiceOver accessibility to announce slope level as part of gauge readings

## Changes

| File | Change |
|------|--------|
| `SlopeIndicator.swift` | New component with caption font, accessibilityHidden |
| `HeadroomRingGauge.swift` | Add optional `slopeLevel` parameter, VStack center content |
| `FiveHourGaugeSection.swift` | Pass `fiveHourSlope`, update accessibility label |
| `SevenDayGaugeSection.swift` | Pass `sevenDaySlope`, update accessibility label |
| `SlopeIndicatorTests.swift` | 27 tests for component, accessibility, format |

## Acceptance Criteria

- [x] AC1: 5h gauge shows SlopeIndicator matching `AppState.fiveHourSlope`
- [x] AC2: 7d gauge shows SlopeIndicator matching `AppState.sevenDaySlope`
- [x] AC3: Insufficient data displays flat arrow as default
- [x] AC4: VoiceOver announces slope as part of gauge reading

## Testing

- 548 tests pass (27 new for this story)
- Build succeeds with no errors
- Code review fixes applied: accessibility tests now verify actual label content

## Notes

- Slope hidden when disconnected (`headroomPercentage` is nil)
- `combinedAccessibilityLabel` made internal for testable verification
- Previews consolidated from 10 blocks to 3 using ForEach

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Slope indicator now displays in headroom gauge popovers with color-coded visual representation.
  * Slope information appears in 5-hour and 7-day gauge displays when connected; hidden when disconnected.

* **Accessibility**
  * Enhanced accessibility labels to include slope level information for improved screen reader support.

* **Tests**
  * Added comprehensive test coverage for slope indicator rendering and gauge accessibility features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->