### PR TITLE
chore: mark Story 12.4 and Epic 12 as done

### DIFF
--- a/_bmad-output/implementation-artifacts/12-4-popover-view-integration.md
+++ b/_bmad-output/implementation-artifacts/12-4-popover-view-integration.md
@@ -1,6 +1,6 @@
 # Story 12.4: PopoverView Integration
 
-Status: review
+Status: done
 
 ## Story
 

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -105,9 +105,9 @@ development_status:
   11-5-slope-indicator-component: cancelled  # Absorbed into 11.4 - SlopeIndicator created there
   epic-11-retrospective: optional
 
-  epic-12: in-progress
+  epic-12: done
   12-1-sparkline-data-preparation: done
   12-2-sparkline-component: done
-  12-3-sparkline-as-analytics-toggle: review
-  12-4-popover-view-integration: review
+  12-3-sparkline-as-analytics-toggle: done
+  12-4-popover-view-integration: done
   epic-12-retrospective: optional


### PR DESCRIPTION
## Summary
- Updates sprint-status.yaml to mark Story 12.4 and Epic 12 as done
- All Phase 3 Epic 12 stories (12.1-12.4) are now complete

This is a status-tracking update following the successful merge of PR #19 (Story 12.4 implementation) and PR #20 (CI test stability fix).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal project status and documentation tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->