### PR TITLE
chore: release v1.1.1

### DIFF
--- a/cc-hdrm/Info.plist
+++ b/cc-hdrm/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.0</string>
+	<string>1.1.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
## Summary

Release v1.1.1 with:
- Updated README documenting burn rate indicator, sparkline, and notifications
- New screenshot showing sparkline and slope indicators
- Fixed release workflow to detect version bumps via Info.plist comparison (works with squash merges)

## v1.1.1 Changelog

### Added
- Burn rate indicator (→ ↗ ⬆) in menu bar and popover
- 24-hour usage sparkline in popover
- Threshold notifications at 20% and 5% headroom

### Fixed
- Release workflow now works with squash merges

### Changed
- Updated README with new features
- Updated screenshot with sparkline visualization