### PR TITLE
feat: persist extra usage data to SQLite database

### DIFF
--- a/cc-hdrm/Models/UsagePoll.swift
+++ b/cc-hdrm/Models/UsagePoll.swift
@@ -14,4 +14,12 @@ struct UsagePoll: Sendable, Equatable {
     let sevenDayUtil: Double?
     /// 7-day window reset time as Unix milliseconds, nil if unavailable
     let sevenDayResetsAt: Int64?
+    /// Whether extra usage billing is enabled, nil if not reported
+    var extraUsageEnabled: Bool? = nil
+    /// Monthly extra usage credit limit, nil if not reported
+    var extraUsageMonthlyLimit: Double? = nil
+    /// Extra usage credits consumed this month, nil if not reported
+    var extraUsageUsedCredits: Double? = nil
+    /// Extra usage utilization fraction (0-1), nil if not reported
+    var extraUsageUtilization: Double? = nil
 }


### PR DESCRIPTION
## Summary
- Adds 4 extra usage columns (`extra_usage_enabled`, `extra_usage_monthly_limit`, `extra_usage_used_credits`, `extra_usage_utilization`) to the `usage_polls` table
- Schema migration v2→v3 with `ALTER TABLE ADD COLUMN` for existing databases
- Extracts `readPollRow` helper to DRY up column reading across `getRecentPolls`, `getLastPoll`, and `queryRawPollsForRollup`
- 7 new tests: v2→v3 migration, column verification, extra usage round-trip persistence

## Test plan
- [x] All 842 tests pass
- [x] Schema migration test verifies v2 database gets extra_usage columns after migration
- [x] Extra usage data round-trips through persistPoll → getRecentPolls/getLastPoll
- [x] Nil extra usage fields stored and read back correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking extra usage metrics including enabled status, monthly limit, used credits, and utilization data.

* **Tests**
  * Added test coverage for extra usage metrics persistence, retrieval, and backward compatibility with previous data versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->