### PR TITLE
docs: mark story 16.3 as done in sprint status

### DIFF
--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -139,7 +139,7 @@ development_status:
   epic-16: in-progress  # Subscription Intelligence (Phase 4)
   16-1-slow-burn-pattern-detection-service: review
   16-2-pattern-notification-analytics-display: backlog
-  16-3-tier-recommendation-service: review
+  16-3-tier-recommendation-service: done
   16-4-tier-recommendation-display-billing-cycle: backlog
   16-5-context-aware-insight-engine: backlog  # Future iteration
   16-6-self-benchmarking-visual-trends: backlog  # Future iteration


### PR DESCRIPTION
## Summary

Updates sprint-status.yaml to mark Story 16.3 (Tier Recommendation Service) as done after PR merge.