### PR TITLE
fix: handle negative savings in tier cost comparison

### DIFF
--- a/cc-hdrm/Services/TierRecommendationService.swift
+++ b/cc-hdrm/Services/TierRecommendationService.swift
@@ -336,7 +336,11 @@ final class TierRecommendationService: TierRecommendationServiceProtocol, @unche
         guard monthlyExtraUsage > 0 else { return nil }
         let currentBase = currentTier.monthlyPrice
         let savings = currentMonthlyCost - recommendedTier.monthlyPrice
-        return "On \(currentTier.displayName) ($\(Int(currentBase))/mo) you paid ~$\(Int(monthlyExtraUsage)) in extra usage ($\(Int(currentMonthlyCost)) total) — \(recommendedTier.displayName) ($\(Int(recommendedTier.monthlyPrice))/mo) would have covered you and saved $\(Int(savings))"
+        if savings > 0 {
+            return "On \(currentTier.displayName) ($\(Int(currentBase))/mo) you paid ~$\(Int(monthlyExtraUsage)) in extra usage ($\(Int(currentMonthlyCost)) total) — \(recommendedTier.displayName) ($\(Int(recommendedTier.monthlyPrice))/mo) would have covered you and saved $\(Int(savings))"
+        } else {
+            return "On \(currentTier.displayName) ($\(Int(currentBase))/mo) you paid ~$\(Int(monthlyExtraUsage)) in extra usage — \(recommendedTier.displayName) ($\(Int(recommendedTier.monthlyPrice))/mo) would eliminate rate limits"
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- Fix `buildCostComparison` in `TierRecommendationService` to handle cases where the recommended tier costs more than the current total (base + extra usage)
- When savings are negative (recommending a higher tier to avoid rate limits, not to save money), display a rate-limit-avoidance message instead of misleading "saved $-30" text

## Context

Addresses CodeRabbit major finding from PR 50 (Story 16.3). The scenario: Pro user ($20/mo) hitting limits with $50 extra usage ($70 total) gets recommended Max 5x ($100/mo). Previously showed "saved $-30" — now shows "would eliminate rate limits".

## Test plan

- [ ] Verify existing TierRecommendationServiceTests still pass
- [ ] Manual: confirm upgrade recommendations with negative savings show rate-limit message