### PR TITLE
feat: extra usage state propagation and menu bar indicator (Story 17.1)

### DIFF
--- a/_bmad-output/implementation-artifacts/17-1-extra-usage-state-menu-bar-indicator.md
+++ b/_bmad-output/implementation-artifacts/17-1-extra-usage-state-menu-bar-indicator.md
@@ -1,0 +1,365 @@
+# Story 17.1: Extra Usage State Propagation & Menu Bar Indicator
+
+Status: review
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+As a developer using Claude Code,
+I want the menu bar to visually distinguish "over plan quota and burning extra credits" from "exhausted and waiting for reset,"
+so that I know at a glance when I'm spending real money beyond my subscription.
+
+## Acceptance Criteria
+
+1. **Given** `UsageResponse.extraUsage` is returned by the API
+   **When** `AppState` processes the poll response
+   **Then** the following extra usage fields are surfaced as observable properties:
+   - `extraUsageEnabled: Bool`
+   - `extraUsageMonthlyLimit: Double?`
+   - `extraUsageUsedCredits: Double?`
+   - `extraUsageUtilization: Double?`
+
+2. **Given** `extraUsage.isEnabled == true` AND either the 5h or 7d plan utilization is at 100% (`.exhausted` state)
+   **When** the menu bar renders
+   **Then** the gauge icon switches to "extra usage mode":
+   - The gauge **repurposes** to show prepaid extra usage balance draining
+   - The text label shows a **currency amount** (e.g., "$27.39") representing the remaining balance, instead of a headroom percentage
+   - The needle direction **reverses** compared to headroom: the arc is **full on the left** and **empty on the right** -- the needle sweeps left-to-right as the prepaid balance drains (opposite of headroom where full is on the right)
+   - This reversed direction + currency symbol makes it unmistakable that the gauge is showing prepaid balance, not plan headroom
+   - The arc color follows a calm-to-warm-to-hot progression as the balance drains toward zero, using colors distinct from the headroom state palette (e.g., a dedicated "extra usage" color ramp that avoids confusion with the green-to-yellow-to-orange-to-red headroom states)
+
+3. **Given** `extraUsage.monthlyLimit` is known
+   **When** the gauge renders in extra usage mode
+   **Then** the needle position reflects remaining balance: `(monthlyLimit - usedCredits) / monthlyLimit` -- full balance = needle on the left (full arc), depleted = needle on the right (empty arc)
+
+4. **Given** `extraUsage.monthlyLimit` is nil (no limit set)
+   **When** the gauge renders in extra usage mode
+   **Then** the text shows the spent amount only (e.g., "$15.61 spent") and the needle position is not meaningful -- use a fixed position or hide the needle
+
+5. **Given** `extraUsage.isEnabled == false` AND plan utilization is at 100%
+   **When** the menu bar renders
+   **Then** it shows the existing `.exhausted` state unchanged
+
+6. **Given** `extraUsage.isEnabled == true` but plan utilization is below 100%
+   **When** the menu bar renders
+   **Then** no extra usage indicator is shown -- normal headroom display applies
+
+7. **Given** `extraUsage` is nil (API did not return it)
+   **When** `AppState` processes the response
+   **Then** extra usage fields default to disabled/nil and no extra usage UI appears
+
+8. **Given** VoiceOver is active and the menu bar is in "burning extra" state
+   **When** VoiceOver reads the status item
+   **Then** it announces: "Claude usage: extra usage active, [amount] spent of [limit]"
+
+9. **Currency note:** The `ExtraUsage` API model (`cc-hdrm/Models/UsageResponse.swift:30-43`) returns `usedCredits` and `monthlyLimit` as raw `Double` values with no currency indicator. Default to `$` (USD) display. If a currency field is discovered during implementation, parse and use it.
+
+## Tasks / Subtasks
+
+- [x] Task 1: Add extra usage state properties to AppState (AC: 1, 7)
+  - [x] 1.1 Add `private(set) var extraUsageEnabled: Bool = false` to `cc-hdrm/State/AppState.swift`
+  - [x] 1.2 Add `private(set) var extraUsageMonthlyLimit: Double? = nil`
+  - [x] 1.3 Add `private(set) var extraUsageUsedCredits: Double? = nil`
+  - [x] 1.4 Add `private(set) var extraUsageUtilization: Double? = nil`
+  - [x] 1.5 Add computed `var isExtraUsageActive: Bool` -- returns `true` when `extraUsageEnabled == true` AND at least one window is `.exhausted`
+  - [x] 1.6 Add computed `var extraUsageRemainingBalance: Double?` -- returns `monthlyLimit - usedCredits` when both are available, nil otherwise
+  - [x] 1.7 Add `func updateExtraUsage(enabled: Bool, monthlyLimit: Double?, usedCredits: Double?, utilization: Double?)` method
+  - [x] 1.8 When extra usage is nil from API, call `updateExtraUsage(enabled: false, monthlyLimit: nil, usedCredits: nil, utilization: nil)`
+
+- [x] Task 2: Wire PollingEngine to propagate extra usage data (AC: 1, 7)
+  - [x] 2.1 In `cc-hdrm/Services/PollingEngine.swift:fetchUsageData()`, extract extra usage from `response.extraUsage` BEFORE `appState.updateWindows()` to avoid transient UI flicker
+  - [x] 2.2 Call `appState.updateExtraUsage(enabled:monthlyLimit:usedCredits:utilization:)` with values from `response.extraUsage` (defaulting `enabled` to `false` when `extraUsage` is nil)
+  - [x] 2.3 Ensure extra usage state is cleared on credential error (in `handleCredentialError()`)
+
+- [x] Task 3: Create extra usage color tokens (AC: 2)
+  - [x] 3.1 Add `ExtraUsageColors/` color set folder in `cc-hdrm/Resources/Assets.xcassets/` with 4 colors: `ExtraUsageCool`, `ExtraUsageWarm`, `ExtraUsageHot`, `ExtraUsageCritical` -- distinct from headroom palette (blue-to-purple-to-magenta-to-red ramp)
+  - [x] 3.2 Add `NSColor.extraUsageColor(for utilization: Double) -> NSColor` extension in `cc-hdrm/Extensions/Color+Headroom.swift` that maps extra usage utilization (0-1) to the 4-tier color ramp
+  - [x] 3.3 Add corresponding SwiftUI `Color` static properties: `.extraUsageCool`, `.extraUsageWarm`, `.extraUsageHot`, `.extraUsageCritical`
+  - [x] 3.4 Add fallback programmatic colors for test targets (same pattern as `fallbackColor(for:)`)
+  - [x] 3.5 Add `NSFont.extraUsageMenuBarFont(for utilization: Double) -> NSFont` -- uses `.semibold` for 0-0.75, `.bold` for 0.75+
+
+- [x] Task 4: Add extra usage gauge mode to GaugeIcon (AC: 2, 3, 4)
+  - [x] 4.1 Add `static func makeExtraUsage(remainingFraction: Double, utilization: Double) -> NSImage` to `cc-hdrm/Views/GaugeIcon.swift`
+  - [x] 4.2 **Reversed needle direction**: `remainingFraction` of 1.0 (full balance) puts needle at LEFT (pi radians), 0.0 (depleted) puts needle at RIGHT (0 radians). Angle formula: `theta = pi * remainingFraction`
+  - [x] 4.3 **Reversed fill arc**: fill sweeps from RIGHT (0 radians) toward LEFT -- the filled portion represents the *drained* balance
+  - [x] 4.4 Color from `NSColor.extraUsageColor(for: utilization)` -- varies by how much of the limit has been consumed
+  - [x] 4.5 Track arc at 25% opacity of the extra usage color (same pattern as headroom gauge)
+  - [x] 4.6 Add `static func makeExtraUsageNoLimit(utilization: Double) -> NSImage` for the no-limit case -- fixed needle at midpoint, fill at 50%, uses extra usage color
+  - [x] 4.7 No 7d overlay in extra usage mode (7d is not relevant when showing extra usage balance)
+
+- [x] Task 5: Update AppState.menuBarText for extra usage mode (AC: 2, 4)
+  - [x] 5.1 Add computed `var menuBarExtraUsageText: String?` to `cc-hdrm/State/AppState.swift` that returns non-nil only when `isExtraUsageActive`
+  - [x] 5.2 When `monthlyLimit` is known: format remaining balance as currency -- e.g., `"$27.39"` using `String(format: "$%.2f", remainingBalance)`
+  - [x] 5.3 When `monthlyLimit` is nil: format as `"$15.61 spent"` using `String(format: "$%.2f spent", usedCredits)`
+  - [x] 5.4 Modify `var menuBarText: String` to check `menuBarExtraUsageText` first -- if non-nil, return it instead of the normal headroom text
+
+- [x] Task 6: Update AppDelegate.updateMenuBarDisplay() for extra usage mode (AC: 2, 3, 4, 5, 6)
+  - [x] 6.1 In `cc-hdrm/App/AppDelegate.swift:updateMenuBarDisplay()`, add an early check: if `appState.isExtraUsageActive`, branch to extra usage rendering
+  - [x] 6.2 Extra usage rendering path: computes remainingFraction, utilization, generates icon, applies extra usage color + font
+  - [x] 6.3 Normal rendering path (existing code) remains unchanged for all non-extra-usage states
+
+- [x] Task 7: Update VoiceOver accessibility for extra usage mode (AC: 8)
+  - [x] 7.1 In `cc-hdrm/App/AppDelegate.swift:updateMenuBarDisplay()`, add extra usage accessibility path
+  - [x] 7.2 When `isExtraUsageActive` AND `monthlyLimit` is known: `"cc-hdrm: Claude usage: extra usage active, [usedCredits] dollars spent of [monthlyLimit] dollar limit"`
+  - [x] 7.3 When `isExtraUsageActive` AND `monthlyLimit` is nil: `"cc-hdrm: Claude usage: extra usage active, [usedCredits] dollars spent, no limit set"`
+
+- [x] Task 8: Write unit tests for AppState extra usage properties (AC: 1, 5, 6, 7)
+  - [x] 8.1 Extended tests in `cc-hdrmTests/State/AppStateTests.swift`
+  - [x] 8.2 Test `isExtraUsageActive` returns `true` when enabled AND 5h exhausted
+  - [x] 8.3 Test `isExtraUsageActive` returns `true` when enabled AND 7d exhausted
+  - [x] 8.4 Test `isExtraUsageActive` returns `false` when enabled but no window exhausted
+  - [x] 8.5 Test `isExtraUsageActive` returns `false` when disabled even if exhausted
+  - [x] 8.6 Test `extraUsageRemainingBalance` computation
+  - [x] 8.7 Test `menuBarText` returns currency format when extra usage active with known limit
+  - [x] 8.8 Test `menuBarText` returns "$X.XX spent" format when extra usage active with no limit
+  - [x] 8.9 Test `menuBarText` returns normal headroom when extra usage inactive
+  - [x] 8.10 Test `updateExtraUsage` clears previous values when called with nil
+
+- [x] Task 9: Write unit tests for GaugeIcon extra usage mode (AC: 2, 3, 4)
+  - [x] 9.1 Extended tests in `cc-hdrmTests/Views/GaugeIconTests.swift`
+  - [x] 9.2 Test `makeExtraUsage` returns non-nil NSImage
+  - [x] 9.3 Test reversed angle formula: `remainingFraction=1.0` produces angle at pi (left), `remainingFraction=0.0` produces angle at 0 (right)
+  - [x] 9.4 Test `makeExtraUsageNoLimit` returns non-nil NSImage
+
+- [x] Task 10: Write unit tests for extra usage color mapping (AC: 2)
+  - [x] 10.1 Test `NSColor.extraUsageColor(for: 0.0)` returns `ExtraUsageCool` color
+  - [x] 10.2 Test `NSColor.extraUsageColor(for: 0.6)` returns `ExtraUsageWarm` color
+  - [x] 10.3 Test `NSColor.extraUsageColor(for: 0.8)` returns `ExtraUsageHot` color
+  - [x] 10.4 Test `NSColor.extraUsageColor(for: 0.95)` returns `ExtraUsageCritical` color
+
+- [x] Task 11: Run `xcodegen generate` and verify compilation + all tests pass
+
+## Dev Notes
+
+### Architecture Context
+
+This story is the first in Epic 17, propagating the `ExtraUsage` data (already fetched from API and persisted to SQLite since PR 43) upward through `AppState` to the menu bar display layer. The data pipeline is complete -- what's missing is the view-layer surface area.
+
+**Key design decisions:**
+- Extra usage is NOT a new `HeadroomState` case -- it's a separate display mode that takes over the gauge when active. `HeadroomState` remains unchanged.
+- The gauge *repurposes* rather than adding a second icon. The reversed needle direction + currency text + distinct color palette provides a clear visual break from the headroom gauge.
+- Extra usage mode activates only when `extraUsageEnabled == true` AND at least one plan window is `.exhausted`. If the user hasn't hit their plan limits, normal headroom display applies even if extra usage is enabled on their account.
+- Currency defaults to `$` (USD). The `ExtraUsage` model does not currently include a currency field. If one is discovered, Story 17.2+ can add parsing.
+
+### Key Integration Points
+
+**Files consumed (read-only):**
+- `cc-hdrm/Models/UsageResponse.swift:30-43` -- `ExtraUsage` struct with `isEnabled`, `monthlyLimit`, `usedCredits`, `utilization`
+- `cc-hdrm/Models/UsagePoll.swift:17-24` -- `extraUsageEnabled`, `extraUsageMonthlyLimit`, `extraUsageUsedCredits`, `extraUsageUtilization` fields
+- `cc-hdrm/Services/DatabaseManager.swift:240-243` -- SQLite columns for extra usage persistence
+- `cc-hdrm/Services/HistoricalDataService.swift:76-79` -- Extra usage extracted from `UsageResponse` during persistence
+- `cc-hdrm/Models/HeadroomState.swift` -- `.exhausted` detection for triggering extra usage mode
+
+**Files to modify:**
+- `cc-hdrm/State/AppState.swift` -- Add 4 extra usage properties, `isExtraUsageActive` computed property, `extraUsageRemainingBalance`, `updateExtraUsage()` method, modify `menuBarText`
+- `cc-hdrm/Services/PollingEngine.swift` -- Wire `response.extraUsage` to `appState.updateExtraUsage()` in `fetchUsageData()` and clear in `handleCredentialError()`
+- `cc-hdrm/Views/GaugeIcon.swift` -- Add `makeExtraUsage()` and `makeExtraUsageNoLimit()` factory methods with reversed needle geometry
+- `cc-hdrm/App/AppDelegate.swift` -- Add extra usage branch in `updateMenuBarDisplay()` for icon, text color, font, and VoiceOver
+- `cc-hdrm/Extensions/Color+Headroom.swift` -- Add `extraUsageColor(for:)` NSColor extension, SwiftUI Color statics, NSFont extension
+
+**Files to create:**
+- `cc-hdrm/Resources/Assets.xcassets/ExtraUsageColors/` -- 4 new color sets (ExtraUsageCool, ExtraUsageWarm, ExtraUsageHot, ExtraUsageCritical) with light/dark variants
+
+**No new Swift source files needed** -- all changes fit into existing files.
+
+### Gauge Reversal Geometry
+
+The headroom gauge uses:
+- Angle: `theta = pi * (1 - headroom/100)` -- 100% headroom = 0 (right), 0% = pi (left)
+- Fill: sweeps from LEFT (pi) toward the needle -- filled = available capacity
+
+The extra usage gauge reverses both:
+- Angle: `theta = pi * remainingFraction` -- 100% remaining = pi (left), 0% = 0 (right)
+- Fill: sweeps from RIGHT (0) toward the needle -- filled = consumed balance
+- Visual effect: as money drains, needle sweeps right and filled arc shrinks from right
+
+```
+Headroom gauge (normal):          Extra usage gauge (reversed):
+   Full ●──────⟩  Empty              Empty ⟨──────● Full balance
+   100%           0%                  0%             100%
+   needle→right   needle→left        needle→left     needle→right
+   fill from left                    fill from right
+```
+
+### Extra Usage Color Ramp
+
+The extra usage color ramp must be **distinct from the headroom palette** to avoid confusion:
+
+| Headroom (plan)     | Extra Usage (money)     |
+|---------------------|------------------------|
+| Green (normal)      | Cool blue/teal (calm)  |
+| Yellow (caution)    | Purple/indigo (warm)   |
+| Orange (warning)    | Magenta/pink (hot)     |
+| Red (critical/exhausted) | Deep red (critical) |
+
+Suggested HSB values for Asset Catalog color sets:
+- `ExtraUsageCool`: HSB(200, 60%, 80%) -- blue-teal
+- `ExtraUsageWarm`: HSB(270, 60%, 75%) -- purple
+- `ExtraUsageHot`: HSB(320, 70%, 80%) -- magenta
+- `ExtraUsageCritical`: HSB(350, 80%, 85%) -- deep red-pink
+
+Dark mode variants should increase brightness by ~10-15% for readability against dark backgrounds.
+
+### Currency Formatting
+
+- Use `String(format: "$%.2f", amount)` for consistent 2-decimal currency display
+- When `monthlyLimit` is known: show remaining balance `"$27.39"` (compact, fits menu bar)
+- When `monthlyLimit` is nil: show spent amount `"$15.61 spent"` (longer but clear)
+- Amounts are API `Double` values -- no locale-specific formatting needed for USD default
+- Future stories can add proper `NumberFormatter` with `.currency` style if API adds currency info
+
+### Extra Usage Mode Activation Logic
+
+```swift
+var isExtraUsageActive: Bool {
+    guard extraUsageEnabled else { return false }
+    let fiveHourExhausted = fiveHour?.headroomState == .exhausted
+    let sevenDayExhausted = sevenDay?.headroomState == .exhausted
+    return fiveHourExhausted || sevenDayExhausted
+}
+```
+
+Priority order in `updateMenuBarDisplay()`:
+1. **Disconnected** -- show X icon + em dash (existing)
+2. **Extra usage active** -- show reversed gauge + currency text (NEW)
+3. **Normal headroom** -- show headroom gauge + percentage/countdown (existing)
+
+### Potential Pitfalls
+
+1. **Race between `updateWindows()` and `updateExtraUsage()`**: Both are called in `fetchUsageData()`. Since both run on `@MainActor`, they're sequential. But the observation loop in `startObservingAppState()` could trigger a re-render between the two calls, showing a transient inconsistent state. Solution: call `updateExtraUsage()` BEFORE `updateWindows()` so extra usage state is set before window state triggers re-render. Alternatively, combine into a single update method.
+
+2. **GaugeIcon canvas reuse**: The extra usage gauge reuses the same 18x18pt canvas and geometry constants (center, radius, needle length). Only the angle formula and color source change. Verify that the reversed fill arc draws correctly in flipped coordinates.
+
+3. **Font width with currency text**: Currency text like "$27.39" is 6 characters, similar to "83% ↗" (5 chars). The `NSStatusItem.variableLength` accommodates this. But "$15.61 spent" is 12 characters -- significantly wider. Test that menu bar layout handles the longer text gracefully, especially on smaller displays. Consider truncating to "$15.61 spt" or just "$15.61" if space is tight.
+
+4. **Extra usage utilization vs remaining fraction**: The API returns `utilization` (0-1 fraction of limit used) but the gauge shows *remaining* balance. `remainingFraction = 1.0 - utilization`. When `monthlyLimit` is nil, utilization may still be non-nil but is less meaningful -- use `usedCredits` for text display.
+
+5. **Edge case: `usedCredits == 0` but extra usage enabled**: When the billing period resets, `usedCredits` may be 0 with `isEnabled == true` and plan not exhausted. The `isExtraUsageActive` check prevents display (plan must be exhausted first). But if plan IS exhausted and credits are 0, the gauge should show full balance remaining.
+
+6. **Asset catalog color sets**: Must create actual `.colorset` directories with `Contents.json` files, not just Swift code. Each color set needs `Any Appearance` and `Dark` variants. Use the same structure as existing `HeadroomColors/` folder.
+
+7. **Observation tracking**: `menuBarText` now branches based on `isExtraUsageActive`, which depends on `extraUsageEnabled`, `fiveHour`, and `sevenDay`. All are `@Observable` properties, so `withObservationTracking` will correctly pick up changes. But verify that the new `menuBarExtraUsageText` computed property accesses all the right properties to register tracking.
+
+8. **PollingEngine ordering**: Currently `updateWindows()` is called at line 164, then `updateConnectionStatus()` at line 166. Extra usage update should go between them (or immediately after `updateWindows()`) to minimize transient UI flicker. The recommended approach is to call `updateExtraUsage()` at line 165, right after `updateWindows()`.
+
+### Previous Story Intelligence
+
+Key learnings from Epic 16 (Stories 16.1-16.6):
+- **AppState update pattern**: All new state goes through `private(set) var` + dedicated `func update*()` methods. Never expose setters directly.
+- **GaugeIcon extension pattern**: New factory methods (`make(...)`) alongside existing ones. The icon namespace is clean and extensible.
+- **Color+Headroom extension**: Both `NSColor` and SwiftUI `Color` extensions live in the same file. Asset catalog + programmatic fallback is the established pattern.
+- **AppDelegate display branch**: The existing code already has `if state == .disconnected` branch in `updateMenuBarDisplay()`. Adding an `if appState.isExtraUsageActive` branch follows the same pattern.
+- **Test pattern**: Extend existing test files rather than creating new ones for property additions.
+
+### Git Intelligence
+
+Recent commits show consistent patterns:
+- Story commits use `feat:` prefix with story reference
+- No external dependencies added in recent stories
+- Test counts explicitly tracked in completion notes
+- Code review catches dead code and format inconsistencies
+
+### Project Structure Notes
+
+Modified files:
+```
+cc-hdrm/State/AppState.swift                    # ADD extra usage state + computed properties + update method + menuBarText branch
+cc-hdrm/Services/PollingEngine.swift             # ADD updateExtraUsage() call in fetchUsageData() and handleCredentialError()
+cc-hdrm/Views/GaugeIcon.swift                    # ADD makeExtraUsage() and makeExtraUsageNoLimit() factory methods
+cc-hdrm/App/AppDelegate.swift                   # ADD extra usage branch in updateMenuBarDisplay()
+cc-hdrm/Extensions/Color+Headroom.swift          # ADD NSColor.extraUsageColor(), Color statics, NSFont.extraUsageMenuBarFont()
+```
+
+New asset catalog entries (not Swift files -- directory/JSON only):
+```
+cc-hdrm/Resources/Assets.xcassets/ExtraUsageColors/ExtraUsageCool.colorset/
+cc-hdrm/Resources/Assets.xcassets/ExtraUsageColors/ExtraUsageWarm.colorset/
+cc-hdrm/Resources/Assets.xcassets/ExtraUsageColors/ExtraUsageHot.colorset/
+cc-hdrm/Resources/Assets.xcassets/ExtraUsageColors/ExtraUsageCritical.colorset/
+```
+
+Test files to modify:
+```
+cc-hdrmTests/State/AppStateTests.swift           # ADD extra usage property tests
+cc-hdrmTests/Views/GaugeIconTests.swift          # ADD extra usage gauge tests
+```
+
+After adding color sets, run `xcodegen generate` to regenerate the Xcode project.
+
+### References
+
+- [Source: _bmad-output/planning-artifacts/epics/epic-17-extra-usage-visibility-alerts-phase-5.md:36-87] - Story 17.1 acceptance criteria
+- [Source: cc-hdrm/Models/UsageResponse.swift:30-43] - ExtraUsage struct definition
+- [Source: cc-hdrm/Models/UsagePoll.swift:17-24] - Extra usage poll persistence fields
+- [Source: cc-hdrm/State/AppState.swift:40-240] - Current AppState with all observable properties
+- [Source: cc-hdrm/Views/GaugeIcon.swift:11-306] - GaugeIcon namespace with make(), makeDisconnected(), angle()
+- [Source: cc-hdrm/Views/GaugeIcon.swift:113-117] - Headroom angle formula: theta = pi * (1 - p)
+- [Source: cc-hdrm/Views/GaugeIcon.swift:177-194] - drawFillArc() implementation for reference
+- [Source: cc-hdrm/App/AppDelegate.swift:310-399] - updateMenuBarDisplay() with gauge icon + accessibility rendering
+- [Source: cc-hdrm/Extensions/Color+Headroom.swift:1-75] - NSColor/Color headroom color pattern
+- [Source: cc-hdrm/Services/PollingEngine.swift:140-244] - fetchUsageData() where extra usage extraction goes
+- [Source: cc-hdrm/Services/PollingEngine.swift:282-302] - handleCredentialError() where extra usage should be cleared
+- [Source: cc-hdrm/Services/DatabaseManager.swift:240-243] - SQLite extra usage columns
+- [Source: cc-hdrm/Services/HistoricalDataService.swift:76-79] - Extra usage extraction during persistence
+
+## Dev Agent Record
+
+### Agent Model Used
+
+Claude Opus 4.6
+
+### Debug Log References
+
+No debug issues encountered.
+
+### Implementation Plan
+
+- Added 4 extra usage stored properties + 2 computed properties + 1 update method to AppState
+- Added `menuBarExtraUsageText` computed property and modified `menuBarText` to check it first
+- Wired PollingEngine to propagate `response.extraUsage` to AppState (called BEFORE `updateWindows()` per Pitfall 1)
+- Cleared extra usage state in `handleCredentialError()`
+- Created 4 asset catalog color sets (ExtraUsageCool/Warm/Hot/Critical) with light+dark variants
+- Added `NSColor.extraUsageColor(for:)` with 4-tier ramp + programmatic fallback
+- Added `NSFont.extraUsageMenuBarFont(for:)` with semibold/bold threshold at 0.75
+- Added SwiftUI Color statics for extra usage colors
+- Added `GaugeIcon.makeExtraUsage()` and `makeExtraUsageNoLimit()` with reversed needle geometry
+- Added extra usage branch in `AppDelegate.updateMenuBarDisplay()` for icon, color, font, and VoiceOver
+- Extended 3 existing test files with 20 new tests covering all acceptance criteria
+
+### Completion Notes List
+
+- All 11 tasks and subtasks implemented and verified
+- 1077 total tests pass (20 new extra usage tests added)
+- All 9 acceptance criteria satisfied
+- No new Swift source files created — all changes in existing files + asset catalog entries
+- PollingEngine calls `updateExtraUsage()` BEFORE `updateWindows()` to prevent transient UI flicker (Pitfall 1)
+- Extra usage gauge uses reversed needle formula: `theta = pi * remainingFraction` (opposite of headroom)
+- Fill arc sweeps from RIGHT toward LEFT (opposite of headroom)
+- Color ramp: blue-teal → purple → magenta → deep red (distinct from headroom's green → yellow → orange → red)
+
+### Change Log
+
+- 2026-02-12: Story 17.1 implemented — Extra usage state propagation and menu bar indicator
+- 2026-02-12: Code review fixes — negative balance formatting, degenerate fill arc, nil credits fallback, API error cleanup, transition logging, 3 new tests
+
+### File List
+
+Modified:
+- cc-hdrm/State/AppState.swift
+- cc-hdrm/Services/PollingEngine.swift
+- cc-hdrm/Views/GaugeIcon.swift
+- cc-hdrm/App/AppDelegate.swift
+- cc-hdrm/Extensions/Color+Headroom.swift
+- cc-hdrmTests/State/AppStateTests.swift
+- cc-hdrmTests/Views/GaugeIconTests.swift
+- cc-hdrmTests/Extensions/ColorHeadroomTests.swift
+- _bmad-output/implementation-artifacts/sprint-status.yaml
+- _bmad-output/planning-artifacts/epics/epic-list.md
+
+Created:
+- cc-hdrm/Resources/Assets.xcassets/ExtraUsageColors/Contents.json
+- cc-hdrm/Resources/Assets.xcassets/ExtraUsageColors/ExtraUsageCool.colorset/Contents.json
+- cc-hdrm/Resources/Assets.xcassets/ExtraUsageColors/ExtraUsageWarm.colorset/Contents.json
+- cc-hdrm/Resources/Assets.xcassets/ExtraUsageColors/ExtraUsageHot.colorset/Contents.json
+- cc-hdrm/Resources/Assets.xcassets/ExtraUsageColors/ExtraUsageCritical.colorset/Contents.json

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -144,3 +144,10 @@ development_status:
   16-5-context-aware-insight-engine: done
   16-6-self-benchmarking-visual-trends: done
   epic-16-retrospective: optional
+
+  epic-17: in-progress  # Extra Usage Visibility & Alerts (Phase 5)
+  17-1-extra-usage-state-menu-bar-indicator: review
+  17-2-popover-extra-usage-card: backlog
+  17-3-analytics-extra-usage-crossover-visualization: backlog
+  17-4-extra-usage-alerts-configuration: backlog
+  epic-17-retrospective: optional

--- a/_bmad-output/planning-artifacts/epics/epic-17-extra-usage-visibility-alerts-phase-5.md
+++ b/_bmad-output/planning-artifacts/epics/epic-17-extra-usage-visibility-alerts-phase-5.md
@@ -1,0 +1,237 @@
+# Epic 17: Extra Usage Visibility & Alerts (Phase 5)
+
+Alex doesn't just hit the wall anymore — when his 5h or 7d plan quota runs out, Anthropic's pay-as-you-go overflow kicks in and cc-hdrm shows him exactly what it's costing. The menu bar glows amber when extra credits are burning, the popover shows a live spend bar with balance and reset date, and the analytics window reveals which cycles crossed the 100% line and by how much. Configurable alerts fire when extra spend crosses thresholds, so Alex never wakes up to a surprise bill.
+
+## Origin
+
+Party mode brainstorming session (2026-02-12). The data pipeline already exists — `ExtraUsage` struct (`cc-hdrm/Models/UsageResponse.swift:30-43`) with `isEnabled`, `monthlyLimit`, `usedCredits`, `utilization` is fetched from the API, persisted to SQLite (`cc-hdrm/Services/DatabaseManager.swift:240-243`), and consumed by `SubscriptionPatternDetector` and `TierRecommendationService`. What's missing is real-time visibility across all three UI layers and proactive alerting.
+
+### Current Extra Usage Data Flow
+
+```
+Claude API /api/oauth/usage → UsageResponse.extraUsage
+    → HistoricalDataService.persistPoll() → SQLite (4 columns)
+    → SubscriptionPatternDetector → PatternFinding (.extraUsageOverflow, .persistentExtraUsage)
+    → TierRecommendationService → cost comparisons with extra usage factored in
+    → ValueInsightEngine → insight candidates (extra usage conclusion types)
+```
+
+### What's Missing
+
+1. **AppState does not surface extra usage** to the view layer for real-time display
+2. **Menu bar has no "burning extra" state** — HeadroomState only covers normal→exhausted
+3. **Popover has no extra usage card** — spend bar, balance, reset date are invisible
+4. **Analytics lacks crossover visualization** — no visual boundary at 100% showing when/how much the user went over
+5. **Extra usage pattern notifications are disabled** — `PatternNotificationService.isNotifiableType()` returns `false` for `.extraUsageOverflow` and `.persistentExtraUsage` (`cc-hdrm/Services/PatternNotificationService.swift:60`)
+6. **No threshold-based alerts** for extra usage spend levels (50%, 75%, 90% of monthly limit)
+
+### Dependencies
+
+- Story 16.4 introduced the billing cycle day preference — extra usage reset date derives from this
+- Story 16.5 insight engine already handles extra usage conclusion candidates
+- Story 16.6 CycleOverCycleBar can be extended with extra usage cost overlay
+
+---
+
+## Story 17.1: Extra Usage State Propagation & Menu Bar Indicator
+
+As a developer using Claude Code,
+I want the menu bar to visually distinguish "over plan quota and burning extra credits" from "exhausted and waiting for reset,"
+So that I know at a glance when I'm spending real money beyond my subscription.
+
+**Acceptance Criteria:**
+
+**Given** `UsageResponse.extraUsage` is returned by the API
+**When** `AppState` processes the poll response
+**Then** the following extra usage fields are surfaced as observable properties:
+
+- `extraUsageEnabled: Bool`
+- `extraUsageMonthlyLimit: Double?`
+- `extraUsageUsedCredits: Double?`
+- `extraUsageUtilization: Double?`
+
+**Given** `extraUsage.isEnabled == true` AND either the 5h or 7d plan utilization is at 100% (`.exhausted` state)
+**When** the menu bar renders
+**Then** the gauge icon switches to "extra usage mode":
+
+- The gauge **repurposes** to show prepaid extra usage balance draining
+- The text label shows a **currency amount** (e.g., "$27.39") representing the remaining balance, instead of a headroom percentage
+- The needle direction **reverses** compared to headroom: the arc is **full on the left** and **empty on the right** — the needle sweeps left-to-right as the prepaid balance drains (opposite of headroom where full is on the right)
+- This reversed direction + currency symbol makes it unmistakable that the gauge is showing prepaid balance, not plan headroom
+- The arc color follows a calm→warm→hot progression as the balance drains toward zero, using colors distinct from the headroom state palette (e.g., a dedicated "extra usage" color ramp that avoids confusion with the green→yellow→orange→red headroom states)
+
+**Given** `extraUsage.monthlyLimit` is known
+**When** the gauge renders in extra usage mode
+**Then** the needle position reflects remaining balance: `(monthlyLimit - usedCredits) / monthlyLimit` — full balance = needle on the left (full arc), depleted = needle on the right (empty arc)
+
+**Given** `extraUsage.monthlyLimit` is nil (no limit set)
+**When** the gauge renders in extra usage mode
+**Then** the text shows the spent amount only (e.g., "$15.61 spent") and the needle position is not meaningful — use a fixed position or hide the needle
+
+**Given** `extraUsage.isEnabled == false` AND plan utilization is at 100%
+**When** the menu bar renders
+**Then** it shows the existing `.exhausted` state unchanged
+
+**Given** `extraUsage.isEnabled == true` but plan utilization is below 100%
+**When** the menu bar renders
+**Then** no extra usage indicator is shown — normal headroom display applies
+
+**Given** `extraUsage` is nil (API did not return it)
+**When** `AppState` processes the response
+**Then** extra usage fields default to disabled/nil and no extra usage UI appears
+
+**Given** VoiceOver is active and the menu bar is in "burning extra" state
+**When** VoiceOver reads the status item
+**Then** it announces: "Claude usage: extra usage active, [amount] spent of [limit]"
+
+**Currency note:** The `ExtraUsage` API model (`cc-hdrm/Models/UsageResponse.swift:30-43`) returns `usedCredits` and `monthlyLimit` as raw `Double` values with no currency indicator. Investigation is needed during implementation to determine whether the API returns amounts in USD or the user's account currency. If the API does not include a currency field, default to `$` (USD) display. If a currency field is discovered, parse and use it.
+
+## Story 17.2: Popover Extra Usage Card
+
+As a developer using Claude Code,
+I want the popover to show my current extra usage spend, limit, and utilization with color-coded urgency,
+So that one click gives me the full picture of what I'm spending beyond my plan.
+
+**Acceptance Criteria:**
+
+**Given** `extraUsage.isEnabled == true` AND `extraUsage.usedCredits > 0`
+**When** the popover renders
+**Then** an "Extra Usage" card appears below the 7d gauge section (before the sparkline):
+
+- A horizontal progress bar showing `usedCredits / monthlyLimit`
+- Text: amount spent and monthly limit in currency (e.g., "$15.61 / $43.00") — currency determined per Story 17.1 currency note
+- Utilization percentage (e.g., "37%")
+- Reset context: derived from billing cycle day preference (Story 16.4), e.g., "Resets Mar 1"
+- If billing cycle day is not configured: show "Set billing day in Settings for reset date"
+
+**Given** extra usage utilization is below 50%
+**When** the card renders
+**Then** the progress bar fill is the standard accent color (calm)
+
+**Given** extra usage utilization is between 50% and 75%
+**When** the card renders
+**Then** the progress bar fill shifts to amber
+
+**Given** extra usage utilization is between 75% and 90%
+**When** the card renders
+**Then** the progress bar fill shifts to orange
+
+**Given** extra usage utilization is above 90%
+**When** the card renders
+**Then** the progress bar fill shifts to red
+
+**Given** `extraUsage.isEnabled == true` AND `extraUsage.usedCredits == 0` or is nil
+**When** the popover renders
+**Then** the extra usage card shows in a minimal collapsed state: "Extra usage: enabled, no spend this period"
+
+**Given** `extraUsage.isEnabled == false` or `extraUsage` is nil
+**When** the popover renders
+**Then** no extra usage card is shown
+
+**Given** `extraUsage.monthlyLimit` is nil (no limit set)
+**When** the card renders
+**Then** show spend amount without the progress bar and without percentage (no denominator)
+
+**Given** VoiceOver focuses the extra usage card
+**When** VoiceOver reads the element
+**Then** it announces: "Extra usage: [amount] spent of [limit] monthly limit, [percentage] used, resets [date]"
+
+## Story 17.3: Analytics Extra Usage Crossover Visualization
+
+As a developer using Claude Code,
+I want the analytics window to show when and how much I went over 100% plan utilization into extra usage,
+So that I can identify patterns in my overflow spending over time.
+
+**Acceptance Criteria:**
+
+**Given** the analytics window is open and extra usage data exists in the selected time range
+**When** the main UsageChart renders
+**Then** a 100% reference line is drawn as a subtle horizontal dashed line across the chart
+**And** periods where utilization was at 100% AND extra usage was active are annotated with a distinct fill or marker above the 100% line
+
+**Given** the CycleOverCycleBar (Story 16.6) renders for a billing cycle where extra usage occurred
+**When** extra usage data is available for that cycle
+**Then** an additional segment appears on top of the regular utilization bar:
+
+- Visually distinct (different color/pattern) from the plan utilization segment
+- Height proportional to extra usage spend relative to base subscription cost
+- Tooltip shows: "Extra: €X.XX" alongside the regular cycle tooltip
+
+**Given** the 30d or All time range is selected and extra usage data spans multiple cycles
+**When** the analytics value section renders
+**Then** a summary of extra usage across cycles is available as an insight candidate:
+
+- Total extra spend across visible cycles
+- Number of cycles with overflow
+- Average extra spend per overflow cycle
+
+**Given** no extra usage data exists in the selected time range
+**When** the chart renders
+**Then** the 100% reference line is still shown (for context) but no extra usage annotations appear
+
+**Given** the 24h or 7d time range is selected
+**When** the chart renders
+**Then** the 100% reference line is shown
+**And** if current poll shows extra usage active, a subtle indicator appears at the current data point
+
+**Given** VoiceOver focuses an extra usage annotation on the chart
+**When** VoiceOver reads the element
+**Then** it announces: "Extra usage active: [amount] spent this period"
+
+## Story 17.4: Extra Usage Alerts & Configuration
+
+As a developer using Claude Code,
+I want configurable alerts when my extra usage crosses spend thresholds,
+So that I'm proactively warned about overflow costs without having to check the app.
+
+**Acceptance Criteria:**
+
+**AC: Enable existing pattern notifications**
+
+**Given** `PatternNotificationService.isNotifiableType()` currently returns `false` for `.extraUsageOverflow` and `.persistentExtraUsage`
+**When** Story 17.4 is implemented
+**Then** both pattern types return `true` (notifications enabled)
+**And** notification content follows the existing `notificationTitle()` and `notificationBody()` patterns
+**And** 30-day cooldown applies (consistent with other pattern notifications)
+
+**AC: Extra usage threshold alerts**
+
+**Given** extra usage is enabled and the user has configured alert thresholds
+**When** extra usage utilization crosses a threshold (default: 50%, 75%, 90%)
+**Then** a macOS notification is delivered:
+
+- At 50%: Title "Extra usage update" / Body "You've used half your extra usage budget ([amount] of [limit])"
+- At 75%: Title "Extra usage warning" / Body "Extra usage at 75% — [amount] of [limit] spent this period"
+- At 90%: Title "Extra usage alert" / Body "Extra usage at 90% — [remaining] left before hitting your monthly limit"
+
+**Given** extra usage utilization crosses from below 100% to at/above 100% (entered extra usage zone)
+**When** the threshold is crossed for the first time in this billing cycle
+**Then** a macOS notification is delivered:
+
+- Title: "Extra usage started"
+- Body: "Your plan quota is exhausted — extra usage is now active"
+- This fires once per billing cycle (re-arms on billing cycle reset)
+
+**Given** a threshold notification has already been sent for a given level in the current billing period
+**When** utilization remains at or above that level
+**Then** no duplicate notification is sent
+**And** the threshold re-arms when a new billing period begins (detected via reset date or utilization dropping to 0)
+
+**AC: Settings UI**
+
+**Given** the settings view is open
+**When** the notification section renders
+**Then** an "Extra Usage Alerts" subsection appears below the existing headroom threshold settings:
+
+- Toggle: "Extra usage alerts" (default: on if extra usage is enabled)
+- Three threshold steppers: 50%, 75%, 90% (each individually toggleable)
+- "Entered extra usage" alert toggle (default: on)
+- Help text: "Get notified when your extra usage spending crosses these thresholds"
+
+**Given** the user disables all extra usage alert toggles
+**When** extra usage thresholds are crossed
+**Then** no notifications are delivered for extra usage (pattern notifications from AC 1 still respect their own toggle)
+
+**Given** extra usage is not enabled on the user's account
+**When** the settings view renders
+**Then** the "Extra Usage Alerts" subsection is hidden or shows: "Extra usage is not enabled on your Anthropic account"

--- a/_bmad-output/planning-artifacts/epics/epic-list.md
+++ b/_bmad-output/planning-artifacts/epics/epic-list.md
@@ -74,3 +74,11 @@ Alex sees the real story behind his usage — a three-band breakdown showing wha
 
 Alex configures how long cc-hdrm keeps historical data and optionally overrides credit limits for unknown subscription tiers.
 **FRs covered:** FR38
+
+## Epic 16: Subscription Intelligence (Phase 4)
+
+Alex doesn't just see what happened — cc-hdrm tells him what it means. Slow-burn patterns surface as macOS notifications before they become costly surprises. Tier recommendations answer "am I on the right plan?" with concrete numbers. The analytics view presents the single most relevant conclusion from multiple valid lenses, anchored against Alex's own usage history.
+
+## Epic 17: Extra Usage Visibility & Alerts (Phase 5)
+
+Alex doesn't just hit the wall anymore — when his 5h or 7d plan quota runs out, Anthropic's pay-as-you-go overflow kicks in and cc-hdrm shows him exactly what it's costing. The menu bar glows amber when extra credits are burning, the popover shows a live spend bar with balance and reset date, and the analytics window reveals which cycles crossed the 100% line and by how much. Configurable alerts fire when extra spend crosses thresholds.

--- a/cc-hdrm/Extensions/Color+Headroom.swift
+++ b/cc-hdrm/Extensions/Color+Headroom.swift
@@ -36,6 +36,46 @@ extension NSColor {
     }
 }
 
+// MARK: - NSColor Extra Usage Mapping
+
+extension NSColor {
+    /// Returns the extra usage color for the given utilization fraction (0-1).
+    /// Uses a 4-tier color ramp distinct from the headroom palette.
+    static func extraUsageColor(for utilization: Double) -> NSColor {
+        let tokenName: String
+        switch utilization {
+        case ..<0.50:
+            tokenName = "ExtraUsageCool"
+        case 0.50..<0.75:
+            tokenName = "ExtraUsageWarm"
+        case 0.75..<0.90:
+            tokenName = "ExtraUsageHot"
+        default:
+            tokenName = "ExtraUsageCritical"
+        }
+
+        let catalogName = "ExtraUsageColors/\(tokenName)"
+        if let color = NSColor(named: NSColor.Name(catalogName)) {
+            return color
+        }
+
+        return fallbackExtraUsageColor(for: utilization)
+    }
+
+    private static func fallbackExtraUsageColor(for utilization: Double) -> NSColor {
+        switch utilization {
+        case ..<0.50:
+            return NSColor(red: 0.320, green: 0.640, blue: 0.800, alpha: 1.0)
+        case 0.50..<0.75:
+            return NSColor(red: 0.500, green: 0.300, blue: 0.750, alpha: 1.0)
+        case 0.75..<0.90:
+            return NSColor(red: 0.800, green: 0.240, blue: 0.600, alpha: 1.0)
+        default:
+            return NSColor(red: 0.850, green: 0.170, blue: 0.250, alpha: 1.0)
+        }
+    }
+}
+
 // MARK: - NSFont Headroom Mapping
 
 extension NSFont {
@@ -54,6 +94,17 @@ extension NSFont {
     }
 }
 
+// MARK: - NSFont Extra Usage Mapping
+
+extension NSFont {
+    /// Returns menu bar font for extra usage mode.
+    /// Uses `.semibold` for 0-0.75 utilization, `.bold` for 0.75+.
+    static func extraUsageMenuBarFont(for utilization: Double) -> NSFont {
+        let weight: NSFont.Weight = utilization >= 0.75 ? .bold : .semibold
+        return NSFont.monospacedSystemFont(ofSize: NSFont.systemFontSize, weight: weight)
+    }
+}
+
 // MARK: - SwiftUI Color Headroom Mapping
 
 extension Color {
@@ -63,6 +114,12 @@ extension Color {
     static var headroomCritical: Color { Color("HeadroomColors/HeadroomCritical", bundle: .main) }
     static var headroomExhausted: Color { Color("HeadroomColors/HeadroomExhausted", bundle: .main) }
     static var disconnected: Color { Color("HeadroomColors/Disconnected", bundle: .main) }
+
+    // Extra Usage Colors
+    static var extraUsageCool: Color { Color("ExtraUsageColors/ExtraUsageCool", bundle: .main) }
+    static var extraUsageWarm: Color { Color("ExtraUsageColors/ExtraUsageWarm", bundle: .main) }
+    static var extraUsageHot: Color { Color("ExtraUsageColors/ExtraUsageHot", bundle: .main) }
+    static var extraUsageCritical: Color { Color("ExtraUsageColors/ExtraUsageCritical", bundle: .main) }
 
     /// Returns the SwiftUI `Color` for the given headroom state.
     /// Delegates to `HeadroomState.swiftUIColor` to avoid duplication.

--- a/cc-hdrm/Resources/Assets.xcassets/ExtraUsageColors/Contents.json
+++ b/cc-hdrm/Resources/Assets.xcassets/ExtraUsageColors/Contents.json
@@ -1,0 +1,9 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "provides-namespace" : true
+  }
+}

--- a/cc-hdrm/Resources/Assets.xcassets/ExtraUsageColors/ExtraUsageCool.colorset/Contents.json
+++ b/cc-hdrm/Resources/Assets.xcassets/ExtraUsageColors/ExtraUsageCool.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.320",
+          "green" : "0.640",
+          "blue" : "0.800",
+          "alpha" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.380",
+          "green" : "0.710",
+          "blue" : "0.900",
+          "alpha" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/cc-hdrm/Resources/Assets.xcassets/ExtraUsageColors/ExtraUsageCritical.colorset/Contents.json
+++ b/cc-hdrm/Resources/Assets.xcassets/ExtraUsageColors/ExtraUsageCritical.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.850",
+          "green" : "0.170",
+          "blue" : "0.250",
+          "alpha" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.950",
+          "green" : "0.230",
+          "blue" : "0.310",
+          "alpha" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/cc-hdrm/Resources/Assets.xcassets/ExtraUsageColors/ExtraUsageHot.colorset/Contents.json
+++ b/cc-hdrm/Resources/Assets.xcassets/ExtraUsageColors/ExtraUsageHot.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.800",
+          "green" : "0.240",
+          "blue" : "0.600",
+          "alpha" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.900",
+          "green" : "0.300",
+          "blue" : "0.680",
+          "alpha" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/cc-hdrm/Resources/Assets.xcassets/ExtraUsageColors/ExtraUsageWarm.colorset/Contents.json
+++ b/cc-hdrm/Resources/Assets.xcassets/ExtraUsageColors/ExtraUsageWarm.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.500",
+          "green" : "0.300",
+          "blue" : "0.750",
+          "alpha" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.570",
+          "green" : "0.360",
+          "blue" : "0.850",
+          "alpha" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/cc-hdrmTests/Extensions/ColorHeadroomTests.swift
+++ b/cc-hdrmTests/Extensions/ColorHeadroomTests.swift
@@ -67,4 +67,70 @@ struct ColorHeadroomTests {
         let font = NSFont.menuBarFont(for: .normal)
         #expect(font.pointSize == NSFont.systemFontSize)
     }
+
+    // MARK: - Extra Usage Color Mapping Tests (Story 17.1)
+
+    @Test("extraUsageColor(for: 0.0) returns ExtraUsageCool color")
+    func extraUsageCoolColor() {
+        let color = NSColor.extraUsageColor(for: 0.0)
+        #expect(color != NSColor.clear, "0.0 utilization should return a non-clear color")
+        // Verify it's blue-ish (cool): blue component should be dominant
+        if let srgb = color.usingColorSpace(.sRGB) {
+            #expect(srgb.blueComponent > srgb.redComponent, "Cool color should have blue > red")
+        }
+    }
+
+    @Test("extraUsageColor(for: 0.6) returns ExtraUsageWarm color")
+    func extraUsageWarmColor() {
+        let color = NSColor.extraUsageColor(for: 0.6)
+        #expect(color != NSColor.clear, "0.6 utilization should return a non-clear color")
+        // Verify it's purple-ish (warm): blue > green
+        if let srgb = color.usingColorSpace(.sRGB) {
+            #expect(srgb.blueComponent > srgb.greenComponent, "Warm color should have blue > green")
+        }
+    }
+
+    @Test("extraUsageColor(for: 0.8) returns ExtraUsageHot color")
+    func extraUsageHotColor() {
+        let color = NSColor.extraUsageColor(for: 0.8)
+        #expect(color != NSColor.clear, "0.8 utilization should return a non-clear color")
+        // Verify it's magenta-ish (hot): red > green
+        if let srgb = color.usingColorSpace(.sRGB) {
+            #expect(srgb.redComponent > srgb.greenComponent, "Hot color should have red > green")
+        }
+    }
+
+    @Test("extraUsageColor(for: 0.95) returns ExtraUsageCritical color")
+    func extraUsageCriticalColor() {
+        let color = NSColor.extraUsageColor(for: 0.95)
+        #expect(color != NSColor.clear, "0.95 utilization should return a non-clear color")
+        // Verify it's red-ish (critical): red > blue and red > green
+        if let srgb = color.usingColorSpace(.sRGB) {
+            #expect(srgb.redComponent > srgb.greenComponent, "Critical color should have red > green")
+            #expect(srgb.redComponent > srgb.blueComponent, "Critical color should have red > blue")
+        }
+    }
+
+    @Test("extraUsageColor tiers are distinct from each other")
+    func extraUsageColorTiersDistinct() {
+        let cool = NSColor.extraUsageColor(for: 0.0)
+        let warm = NSColor.extraUsageColor(for: 0.6)
+        let hot = NSColor.extraUsageColor(for: 0.8)
+        let critical = NSColor.extraUsageColor(for: 0.95)
+
+        #expect(cool != warm, "Cool and warm should be different colors")
+        #expect(warm != hot, "Warm and hot should be different colors")
+        #expect(hot != critical, "Hot and critical should be different colors")
+    }
+
+    @Test("extraUsageMenuBarFont uses semibold below 0.75, bold at 0.75+")
+    func extraUsageFontWeights() {
+        let lowFont = NSFont.extraUsageMenuBarFont(for: 0.3)
+        let highFont = NSFont.extraUsageMenuBarFont(for: 0.8)
+        let expectedLow = NSFont.monospacedSystemFont(ofSize: NSFont.systemFontSize, weight: .semibold)
+        let expectedHigh = NSFont.monospacedSystemFont(ofSize: NSFont.systemFontSize, weight: .bold)
+
+        #expect(lowFont.fontName == expectedLow.fontName, "Below 0.75 should use semibold")
+        #expect(highFont.fontName == expectedHigh.fontName, "At 0.75+ should use bold")
+    }
 }

--- a/cc-hdrmTests/Views/GaugeIconTests.swift
+++ b/cc-hdrmTests/Views/GaugeIconTests.swift
@@ -190,4 +190,66 @@ struct GaugeIconTests {
         #expect(promotedData != nil)
         #expect(baseData != promotedData, "Promoted overlay should produce different pixel data than no overlay")
     }
+
+    // MARK: - Extra Usage Gauge Tests (Story 17.1)
+
+    @Test("makeExtraUsage returns non-nil 18x18 NSImage")
+    func extraUsageGaugeReturnsValidImage() {
+        let image = GaugeIcon.makeExtraUsage(remainingFraction: 0.7, utilization: 0.3)
+        #expect(image.size.width == 18)
+        #expect(image.size.height == 18)
+        #expect(image.isTemplate == false)
+    }
+
+    @Test("extraUsageAngle: remainingFraction=1.0 produces angle at pi (left)")
+    func extraUsageAngleFullBalance() {
+        let angle = GaugeIcon.extraUsageAngle(for: 1.0)
+        #expect(abs(angle - Double.pi) < 0.001, "Full balance should be at pi (left)")
+    }
+
+    @Test("extraUsageAngle: remainingFraction=0.0 produces angle at 0 (right)")
+    func extraUsageAngleDepleted() {
+        let angle = GaugeIcon.extraUsageAngle(for: 0.0)
+        #expect(abs(angle - 0) < 0.001, "Depleted should be at 0 (right)")
+    }
+
+    @Test("extraUsageAngle: remainingFraction=0.5 produces angle at pi/2 (up)")
+    func extraUsageAngleHalfBalance() {
+        let angle = GaugeIcon.extraUsageAngle(for: 0.5)
+        #expect(abs(angle - Double.pi / 2) < 0.001, "Half balance should be at pi/2 (up)")
+    }
+
+    @Test("makeExtraUsageNoLimit returns non-nil 18x18 NSImage")
+    func extraUsageNoLimitReturnsValidImage() {
+        let image = GaugeIcon.makeExtraUsageNoLimit(utilization: 0.5)
+        #expect(image.size.width == 18)
+        #expect(image.size.height == 18)
+        #expect(image.isTemplate == false)
+    }
+
+    @Test("makeExtraUsage at remainingFraction=0.0 (fully depleted) renders fill arc")
+    func extraUsageFullyDepletedRendersFill() {
+        let depleted = GaugeIcon.makeExtraUsage(remainingFraction: 0.0, utilization: 1.0)
+        let trackOnly = GaugeIcon.makeExtraUsage(remainingFraction: 1.0, utilization: 0.0)
+
+        let depletedData = depleted.tiffRepresentation
+        let trackData = trackOnly.tiffRepresentation
+
+        #expect(depletedData != nil)
+        #expect(trackData != nil)
+        #expect(depletedData != trackData, "Fully depleted gauge should differ from full balance (fill arc should render)")
+    }
+
+    @Test("Extra usage gauge produces different pixel data than headroom gauge")
+    func extraUsageGaugeDiffersFromHeadroom() {
+        let headroomImage = GaugeIcon.make(headroomPercentage: 50, state: .caution, sevenDayOverlay: .none)
+        let extraImage = GaugeIcon.makeExtraUsage(remainingFraction: 0.5, utilization: 0.5)
+
+        let headroomData = headroomImage.tiffRepresentation
+        let extraData = extraImage.tiffRepresentation
+
+        #expect(headroomData != nil)
+        #expect(extraData != nil)
+        #expect(headroomData != extraData, "Extra usage gauge should differ from headroom gauge")
+    }
 }


### PR DESCRIPTION
## Summary

- Surfaces `ExtraUsage` API data through `AppState` to the menu bar display, switching the gauge to a reversed-needle mode with currency text and a distinct blue-purple-magenta-red color ramp when the user exhausts their plan and has extra usage enabled
- Adds 4 observable extra usage properties, `isExtraUsageActive` computed property, and `menuBarExtraUsageText` with proper currency formatting (including negative balance handling)
- Creates `GaugeIcon.makeExtraUsage()` / `makeExtraUsageNoLimit()` with reversed needle geometry, extra usage color/font mapping, VoiceOver support, and display mode transition logging
- 23 new tests across 3 test files (1080 total passing)

## Code Review Fixes Included

- **H1**: Negative remaining balance now formats as `-$5.23` instead of `$-5.23`
- **M1**: Fixed degenerate fill arc at `remainingFraction=0.0` (fully depleted gauge now renders full drain arc)
- **M2**: Added `$0.00` fallback in `menuBarExtraUsageText` when active but no credits data (prevents icon/text mismatch)
- **M3**: Added display mode transition logging for entering/exiting extra usage mode
- **M4**: Extra usage state now cleared on API errors (not just credential errors)
- **L1-L2**: Added 3 new tests for negative balance, nil credits fallback, and depleted gauge fill arc

## Test plan

- [x] All 1080 tests pass (23 new extra usage tests)
- [x] Verify `menuBarText` returns `$27.39` when extra usage active with known limit
- [x] Verify `menuBarText` returns `$15.61 spent` when no monthly limit set
- [x] Verify `menuBarText` returns `-$5.23` when used credits exceed limit
- [x] Verify `menuBarText` returns `$0.00` fallback when active but no credits data
- [x] Verify normal headroom display unchanged when extra usage inactive
- [x] Verify gauge icon renders reversed needle (full balance=left, depleted=right)
- [x] Verify extra usage colors are distinct from headroom palette
- [x] Verify VoiceOver announces extra usage state with dollar amounts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Extra Usage display mode to the menu bar, activated when plan limits are exceeded.
  * Currency-based indicators show spending when extra usage is active.
  * Dedicated visual styling and color scheme for extra usage visualization.
  * Reversed gauge mechanics clearly distinguish extra usage from standard headroom display.

* **Documentation**
  * Introduced Epic 17 planning documentation for Extra Usage Visibility & Alerts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->