### PR TITLE
fix: 100% reference line visibility and extra usage 7d trigger

### DIFF
--- a/cc-hdrm/Views/BarChartView.swift
+++ b/cc-hdrm/Views/BarChartView.swift
@@ -405,7 +405,7 @@ private struct StaticBarChartContent: View {
                 }
             }
         }
-        .chartYScale(domain: 0...100)
+        .chartYScale(domain: 0...105)
         .chartLegend(.hidden)
         .chartYAxis {
             AxisMarks(values: [0, 25, 50, 75, 100]) { value in

--- a/cc-hdrm/Views/StepAreaChartView.swift
+++ b/cc-hdrm/Views/StepAreaChartView.swift
@@ -193,8 +193,7 @@ struct StepAreaChartView: View {
             }
 
             let isExtraUsageActive = poll.extraUsageEnabled == true
-                && poll.fiveHourUtil != nil
-                && poll.fiveHourUtil! >= 99.5
+                && ((poll.fiveHourUtil ?? 0) >= 99.5 || (poll.sevenDayUtil ?? 0) >= 99.5)
 
             return ChartPoint(
                 id: index,
@@ -537,7 +536,7 @@ private struct StaticChartContent: View {
                     .lineStyle(StrokeStyle(lineWidth: 1, dash: [6, 4]))
             }
         }
-        .chartYScale(domain: 0...100)
+        .chartYScale(domain: 0...105)
         .chartLegend(.hidden)
         .chartYAxis {
             AxisMarks(values: [0, 25, 50, 75, 100]) { value in

--- a/cc-hdrmTests/Views/UsageChartTests.swift
+++ b/cc-hdrmTests/Views/UsageChartTests.swift
@@ -1143,7 +1143,35 @@ struct UsageChartTests {
         let nowMs: Int64 = Int64(Date().timeIntervalSince1970 * 1000)
         let polls = [
             UsagePoll(id: 1, timestamp: nowMs, fiveHourUtil: 85.0,
-                      fiveHourResetsAt: nil, sevenDayUtil: nil, sevenDayResetsAt: nil,
+                      fiveHourResetsAt: nil, sevenDayUtil: 40.0, sevenDayResetsAt: nil,
+                      extraUsageEnabled: true, extraUsageMonthlyLimit: 100,
+                      extraUsageUsedCredits: 5.0, extraUsageUtilization: 0.05)
+        ]
+        let points = StepAreaChartView.makeChartPoints(from: polls)
+        #expect(points.count == 1)
+        #expect(points[0].extraUsageActive == false)
+    }
+
+    @Test("makeChartPoints sets extraUsageActive=true when sevenDayUtil >= 99.5 even if fiveHourUtil is low")
+    func extraUsageActiveWhenSevenDayUtilHigh() {
+        let nowMs: Int64 = Int64(Date().timeIntervalSince1970 * 1000)
+        let polls = [
+            UsagePoll(id: 1, timestamp: nowMs, fiveHourUtil: 50.0,
+                      fiveHourResetsAt: nil, sevenDayUtil: 100.0, sevenDayResetsAt: nil,
+                      extraUsageEnabled: true, extraUsageMonthlyLimit: 100,
+                      extraUsageUsedCredits: 10.0, extraUsageUtilization: 0.10)
+        ]
+        let points = StepAreaChartView.makeChartPoints(from: polls)
+        #expect(points.count == 1)
+        #expect(points[0].extraUsageActive == true)
+    }
+
+    @Test("makeChartPoints sets extraUsageActive=false when both fiveHourUtil and sevenDayUtil below 99.5")
+    func extraUsageNilWhenBothUtilBelow995() {
+        let nowMs: Int64 = Int64(Date().timeIntervalSince1970 * 1000)
+        let polls = [
+            UsagePoll(id: 1, timestamp: nowMs, fiveHourUtil: 90.0,
+                      fiveHourResetsAt: nil, sevenDayUtil: 85.0, sevenDayResetsAt: nil,
                       extraUsageEnabled: true, extraUsageMonthlyLimit: 100,
                       extraUsageUsedCredits: 5.0, extraUsageUtilization: 0.05)
         ]


### PR DESCRIPTION
## Summary
- **Fixes #64**: Extend chart Y-axis domain from `0...100` to `0...105` so the 100% dashed reference line is visible (was clipped at chart boundary). Applied to both StepAreaChartView and BarChartView.
- **Fixes #65**: Extra usage annotations now trigger when *either* 5h OR 7d utilization hits 99.5% (was 5h-only). The API activates extra usage from either limit being hit.

## Test plan
- [x] New test: `extraUsageActiveWhenSevenDayUtilHigh` — verifies 7d trigger path
- [x] New test: `extraUsageNilWhenBothUtilBelow995` — verifies both-below returns false
- [x] Updated test: `extraUsageInactiveWhenUtilLow` — added `sevenDayUtil: 40.0` for correctness
- [x] All 1160 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Extended chart display range to accommodate values up to 105% without clipping.
  * Refined extra usage activation logic to trigger when either metric reaches the threshold, providing more flexible detection.

* **Tests**
  * Enhanced test coverage for extra usage scenarios, edge cases, and activation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->