### PR TITLE
fix: chart x-axis domain clamping and 7d reset detection

### DIFF
--- a/cc-hdrm/Views/BarChartView.swift
+++ b/cc-hdrm/Views/BarChartView.swift
@@ -342,6 +342,25 @@ private struct StaticBarChartContent: View {
         }
     }
 
+    /// Computes the x-axis domain to cover the full selected time range,
+    /// not just the data range. For `.all`, falls back to data bounds or 90 days.
+    private var xAxisDomain: ClosedRange<Date> {
+        let now = Date()
+        switch timeRange {
+        case .day:
+            return Calendar.current.date(byAdding: .day, value: -1, to: now)!...now
+        case .week:
+            return Calendar.current.date(byAdding: .day, value: -7, to: now)!...now
+        case .month:
+            return Calendar.current.date(byAdding: .day, value: -30, to: now)!...now
+        case .all:
+            if let earliest = barPoints.first?.periodStart {
+                return earliest...now
+            }
+            return Calendar.current.date(byAdding: .day, value: -90, to: now)!...now
+        }
+    }
+
     var body: some View {
         Chart {
             // Layer 0: No-data gap regions (grey background) — rendered before bars so bars draw on top
@@ -406,6 +425,7 @@ private struct StaticBarChartContent: View {
             }
         }
         .chartYScale(domain: 0...105)
+        .chartXScale(domain: xAxisDomain)
         .chartLegend(.hidden)
         .chartYAxis {
             AxisMarks(values: [0, 25, 50, 75, 100]) { value in

--- a/cc-hdrm/Views/StepAreaChartView.swift
+++ b/cc-hdrm/Views/StepAreaChartView.swift
@@ -226,10 +226,26 @@ struct StepAreaChartView: View {
 
         var resets: [Date] = []
         for i in 1..<polls.count {
+            let resetDate = Date(timeIntervalSince1970: Double(polls[i].timestamp) / 1000.0)
+            var detected = false
+
+            // Check 5h utilization drop
             if let prevUtil = polls[i - 1].fiveHourUtil,
                let currUtil = polls[i].fiveHourUtil,
                prevUtil - currUtil >= dropThreshold {
-                resets.append(Date(timeIntervalSince1970: Double(polls[i].timestamp) / 1000.0))
+                detected = true
+            }
+
+            // Check 7d utilization drop
+            if !detected,
+               let prevUtil = polls[i - 1].sevenDayUtil,
+               let currUtil = polls[i].sevenDayUtil,
+               prevUtil - currUtil >= dropThreshold {
+                detected = true
+            }
+
+            if detected {
+                resets.append(resetDate)
             }
         }
         return resets


### PR DESCRIPTION
## Summary
- **Fixes #39**: BarChartView now clamps x-axis to the full selected time range (7d, 30d, All) via `.chartXScale(domain:)`. Previously auto-scaled to data bounds only.
- **Fixes #66**: `findResetTimestamps` now detects 7d utilization drops (>= 10pp) in addition to 5h drops, rendering dashed reset boundary markers on the 24h chart.
- **Fixes #40** (partial): `detectAndRecordResetIfNeeded` now detects 7d resets via `sevenDayResetsAt` timestamp shifts and 7d utilization drops. Recorded as standard reset events (same table, no schema change). Visual distinction between 5h and 7d markers deferred to a future story.

## Test plan
- [x] New test: `resetBoundaryDetectsSevenDayDrop` — 7d drop detected when 5h stable
- [x] New test: `resetBoundaryDeduplicatesBothDrops` — simultaneous drops produce 1 reset
- [x] New test: `barChartXAxisDomainRendersWithoutCrash` — sparse data renders with full domain
- [x] All 1160 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  - Enhanced reset detection to identify both 5‑hour and 7‑day reset patterns with distinct messages and deduplication so a single reset is reported when both patterns coincide
  - Improved chart x‑axis alignment to span the full selected time range, with safer handling for sparse/all‑time data

* **Tests**
  - Added regression tests covering 7‑day reset detection, deduplication, and bar chart x‑axis rendering without crashes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->