### PR TITLE
[minor] release: 1.5.0 — Token Efficiency Ratio, Homebrew quarantine fix

### DIFF
--- a/cc-hdrm/Info.plist
+++ b/cc-hdrm/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4.9</string>
+	<string>1.5.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
<!-- release-notes-start -->
This release ships the Token Efficiency Ratio feature (Epic 20) and fixes the Homebrew quarantine issue.

**Token Efficiency Ratio (TPP)**: cc-hdrm now correlates token consumption from Claude Code session logs with utilization changes, showing how many tokens burn 1% of the 5h budget. Includes an opt-in Measure button for calibrated readings, a trend chart in the analytics window, and historical backfill.

**Homebrew fix**: the cask now strips the Gatekeeper quarantine flag automatically after install/upgrade, so the app launches without the manual xattr workaround (fixes issue 101).
<!-- release-notes-end -->

Release PR — triggers minor version bump to 1.5.0 via PR title keyword.

Includes everything on master since v1.4.9:
- Epic 20: Token Efficiency Ratio (Stories 20.1–20.5) with follow-up chart fixes
- Homebrew cask quarantine-strip postflight (issue 101)
- Documentation and sprint-status updates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app version to 1.5.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->