### PR TITLE
fix: repair time-of-day flaky daily-average test

### DIFF
--- a/_bmad-output/implementation-artifacts/bmad-build-auto-result-21-1-scoped-limits-parsing.md
+++ b/_bmad-output/implementation-artifacts/bmad-build-auto-result-21-1-scoped-limits-parsing.md
@@ -1,0 +1,28 @@
+---
+status: blocked
+---
+
+# BMad Build Auto Result
+
+Status: blocked
+Blocking condition: dirty working tree — uncommitted changes on `master` block the version-control sanity check (step-01, item 3).
+
+## Details
+
+- Intent resolved: Story 21.1 "Scoped Limits Parsing & Domain Model" (Epic 21: Fable Model Usage Tracking).
+- Epic context compiled successfully to `_bmad-output/implementation-artifacts/epic-21-context.md`.
+- Uncommitted files at check time:
+  - Modified: `_bmad-output/implementation-artifacts/sprint-status.yaml`
+  - Modified: `_bmad-output/planning-artifacts/epics/epic-list.md`
+  - Modified: `_bmad-output/planning-artifacts/prd.md`
+  - Untracked: `_bmad-output/planning-artifacts/epics/epic-21-fable-model-usage-tracking.md`
+  - Untracked: `_bmad-output/planning-artifacts/sprint-change-proposal-2026-08-12-codex.md`
+  - Untracked: `_bmad-output/planning-artifacts/sprint-change-proposal-2026-08-12-fable.md`
+  - Untracked: `_bmad-output/implementation-artifacts/epic-21-context.md` (created by this run)
+- Branch at check time: `master` (story work also needs its own branch).
+
+## To unblock
+
+1. Commit (or stash) the Epic 21 planning artifacts — they look like the output of the 2026-08-12 sprint change proposal session.
+2. Create a story branch for Epic 21 work.
+3. Re-run `/bmad-build-auto 21.1`.

--- a/_bmad-output/implementation-artifacts/epic-21-context.md
+++ b/_bmad-output/implementation-artifacts/epic-21-context.md
@@ -1,0 +1,52 @@
+# Epic 21 Context: Fable Model Usage Tracking (Phase 6)
+
+<!-- Generated from planning artifacts. Regenerate with compile-epic-context if planning docs change. -->
+
+## Goal
+
+Claude Fable 5 has its own model-scoped weekly cap (50% of the weekly limit on Max plans) that the app cannot see today. A user can hit the Fable wall while the app reports healthy overall headroom (observed live: Fable 63% vs weekly 67% — the two run independently). This epic parses the usage API's new `limits` array, surfaces the Fable window everywhere existing windows appear (popover, history, analytics, notifications, benchmark), and stays completely invisible for accounts without Fable access.
+
+## Stories
+
+- Story 21.1: Scoped Limits Parsing & Domain Model
+- Story 21.2: Popover Fable Utilization Display
+- Story 21.3: Persistence & Analytics Series
+- Story 21.4: Fable Threshold Notifications
+- Story 21.5: Benchmark Default Model Update
+
+## Requirements & Constraints
+
+- The `/api/oauth/usage` response now includes a `limits` array (source of truth for model-scoped caps). Entry fields: `kind` (`session`, `weekly_all`, `weekly_scoped`), `group`, `percent` (0–100), `severity`, `resets_at` (ISO 8601 or null), `is_active`, and `scope` — null for unscoped entries; for scoped entries `scope.model.display_name` carries the label (e.g. "Fable") and `scope.model.id` may be null. `scope.surface` exists and may be null.
+- Legacy per-model windows (`seven_day_sonnet`, `seven_day_opus`) now return `null` and are superseded — the `sevenDaySonnet` parsing is dead code to remove.
+- The response also gained a `spend` object and extended `extra_usage` fields (`daily`, `weekly`, `currency`) — explicitly out of scope for this epic; ignore them.
+- Absent `limits` array, or no `weekly_scoped` entries, must decode cleanly to nil: no crash, nothing displayed, no behavior change. Every feature in this epic degrades to "not shown".
+- Benchmark model list gains `claude-fable-5`; the benchmark request path must work end to end with that model ID.
+
+Success criteria:
+
+- Popover shows Fable utilization + reset countdown when the API reports a scoped weekly limit; shows nothing when it doesn't.
+- Fable history appears in analytics after at least one poll cycle post-migration.
+- Notifications fire at 20% and 5% Fable headroom, once per threshold crossing.
+- Benchmark can measure `claude-fable-5` end to end.
+- Zero behavior change for accounts without Fable access.
+
+## Technical Decisions
+
+- **Generic parsing, no hardcoded model names.** Decode `weekly_scoped` entries into a generic scoped-limit struct and label UI with the API's `scope.model.display_name`. Future model-scoped caps must appear without code changes.
+- **Additive only.** New optional fields in the response model; new nullable SQLite columns (`fable_weekly_util REAL`, `fable_weekly_resets_at INTEGER` on `usage_snapshots`, plus matching rollup aggregates). Schema migration bumps the tracked schema version. No new services, no new patterns.
+- **Copy existing precedents rather than inventing:** window display follows the existing 5h/7d window components; persistence follows the Epic 17 extra-usage column migration precedent (`cc-hdrm/Services/DatabaseManager.swift`, `cc-hdrm/Services/HistoricalDataService.swift`, `cc-hdrm/Models/UsagePoll.swift`); notifications follow the existing 20%/5% headroom model in `cc-hdrm/Services/NotificationService.swift`; benchmark follows Epic 20 (`cc-hdrm/Views/BenchmarkSectionView.swift`, `cc-hdrm/Services/BenchmarkService.swift`).
+- Rollups are lazy (computed on analytics open); the new columns must flow through the existing snapshot → rollup aggregation path.
+- The token-throughput pipeline (Epic 20) is already model-agnostic — Fable tokens flow through the existing log parser keyed by model string. Only the benchmark default model list changes.
+
+## UX & Interaction Patterns
+
+- Popover detailed panel: one additional row/gauge for the scoped limit, labeled with the API-provided display name, with reset countdown in both relative and absolute form — matching the existing windows exactly. Hidden entirely when no scoped limit is reported.
+- Analytics window: one additional series toggle for Fable utilization, following the existing series-toggle pattern. No new interaction design anywhere in this epic.
+- Benchmark UI copy must note that Fable benchmarks consume the Fable cap; the benchmark stays behind the existing opt-in Measure button.
+
+## Cross-Story Dependencies
+
+- 21.1 → 21.2 → 21.3 → 21.4 are sequential; each builds on the parsed domain data from 21.1.
+- 21.5 (benchmark) is independent of 21.1–21.4 and can run at any time.
+- 21.3 depends on the Epic 17 migration precedent already in the codebase; 21.4 dedup state must be independent per window so Fable alerts don't suppress or duplicate existing window alerts.
+- `sprint-status.yaml` is a shared resource — each story branch updates only its own entry.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -188,3 +188,33 @@ development_status:
   20-3-tpp-data-model-passive-measurement-engine: done  # Code review passed 2026-03-27
   20-4-tpp-trend-visualization: done  # Code review passed 2026-03-27
   20-5-historical-tpp-backfill: done  # Code review passed 2026-03-27
+
+  # Sprint Change Proposal 2026-08-12 (Fable) — new epic
+  epic-21: backlog  # Fable Model Usage Tracking (Phase 6) — Sprint change proposal 2026-08-12
+  21-1-scoped-limits-parsing-domain-model: backlog
+  21-2-popover-fable-utilization-display: backlog
+  21-3-fable-persistence-analytics-series: backlog
+  21-4-fable-threshold-notifications: backlog
+  21-5-benchmark-default-model-update: backlog
+
+  # Sprint Change Proposal 2026-08-12 (Codex) — Phase 7
+  epic-22: backlog  # Codex Data Pipeline & API Spike — 22.1 is kill gate for Phase 7
+  22-1-codex-api-spike: backlog
+  22-2-codex-credentials-service: backlog
+  22-3-codex-api-client-defensive-parsing: backlog
+  22-4-codex-polling-lane-expiry-handling: backlog
+
+  epic-23: backlog  # Codex Menu Bar & Popover
+  23-1-second-status-item-headroom-display: backlog
+  23-2-codex-popover-panel: backlog
+  23-3-codex-error-status-states: backlog
+  23-4-codex-slope-indicators: backlog
+
+  epic-24: backlog  # Codex Notifications & Settings
+  24-1-codex-threshold-notifications: backlog
+  24-2-codex-settings-integration: backlog
+
+  epic-25: backlog  # Codex History & Analytics
+  25-1-provider-dimension-schema-migration: backlog
+  25-2-codex-poll-persistence-rollups: backlog
+  25-3-analytics-provider-integration: backlog

--- a/_bmad-output/planning-artifacts/epics/epic-21-fable-model-usage-tracking.md
+++ b/_bmad-output/planning-artifacts/epics/epic-21-fable-model-usage-tracking.md
@@ -1,0 +1,97 @@
+# Epic 21: Fable Model Usage Tracking (Phase 6)
+
+**Origin:** Sprint change proposal 2026-08-12 (`_bmad-output/planning-artifacts/sprint-change-proposal-2026-08-12.md`)
+
+## Goal
+
+Claude Fable 5 has a model-scoped weekly cap (50% of the weekly limit on Max
+plans) that cc-hdrm cannot see. A user can hit the Fable wall while the app
+reports healthy overall headroom (observed live: Fable 63% vs weekly 67%).
+Parse the usage API's new `limits` array, surface the Fable window everywhere
+the existing windows appear, and keep it out of the way for accounts without
+Fable access.
+
+## API Evidence (live capture 2026-08-12)
+
+The `/api/oauth/usage` response gained a `limits` array. The Fable cap:
+
+```json
+{
+  "kind": "weekly_scoped",
+  "group": "weekly",
+  "percent": 63,
+  "severity": "normal",
+  "resets_at": "2026-08-12T22:00:00.059415+00:00",
+  "scope": { "model": { "id": null, "display_name": "Fable" }, "surface": null },
+  "is_active": false
+}
+```
+
+Legacy `seven_day_sonnet` / `seven_day_opus` fields now return `null` —
+the `limits` array is the source of truth for model-scoped caps.
+
+## Design Principles
+
+- **Generic parsing, no hardcoded model names.** Decode `weekly_scoped`
+  entries and label the UI with the API's `scope.model.display_name`. Future
+  model-scoped caps appear without code changes.
+- **Additive only.** New optional fields, new nullable DB columns. Absent
+  scoped limit → nothing shown, no behavior change.
+- **Copy existing patterns.** Window display (Epic 3/4), persistence
+  (Epic 10/17), notifications (Epic 5), benchmark (Epic 20).
+
+## Stories
+
+### Story 21.1: Scoped Limits Parsing & Domain Model
+
+Decode the `limits` array in `cc-hdrm/Models/UsageResponse.swift` (`kind`,
+`group`, `percent`, `severity`, `resets_at`, `is_active`,
+`scope.model.display_name`). Surface `weekly_scoped` entries through the
+domain layer to consumers. Remove the dead `sevenDaySonnet` field.
+**AC:** Fable percent + reset time available to views; response without
+`limits` (or without scoped entries) decodes cleanly to nil — no crash, no
+display.
+
+### Story 21.2: Popover Fable Utilization Display
+
+Add a scoped-limit row/gauge to the detailed usage panel, labeled with the
+API's `display_name`, with reset countdown (relative + absolute, matching
+existing windows). Hidden when no scoped limit is reported.
+
+### Story 21.3: Persistence & Analytics Series
+
+Additive schema migration: `fable_weekly_util REAL`,
+`fable_weekly_resets_at INTEGER` on `usage_snapshots` plus rollup
+aggregates, following the Epic 17 extra-usage column precedent
+(`cc-hdrm/Services/DatabaseManager.swift`,
+`cc-hdrm/Services/HistoricalDataService.swift`,
+`cc-hdrm/Models/UsagePoll.swift`). Analytics window gains a Fable series
+toggle.
+
+### Story 21.4: Fable Threshold Notifications
+
+20%/5% headroom notifications for the scoped window via
+`cc-hdrm/Services/NotificationService.swift`. Independent dedup per window
+(fire once per crossing), respecting existing threshold preferences.
+
+### Story 21.5: Benchmark Default Model Update
+
+Add `claude-fable-5` to `defaultModels` in
+`cc-hdrm/Views/BenchmarkSectionView.swift`. Verify the
+`cc-hdrm/Services/BenchmarkService.swift` request path works with the Fable
+model ID. UI copy notes that Fable benchmarks consume the Fable cap
+(benchmark stays behind the opt-in Measure button). Independent of 21.1–21.4.
+
+## Sequencing
+
+21.1 → 21.2 → 21.3 → 21.4 (each builds on the parsed domain data).
+21.5 is independent, can run any time.
+
+## Success Criteria
+
+- Popover shows Fable utilization + reset countdown when the API reports a
+  scoped weekly limit; shows nothing when it doesn't.
+- Fable history appears in analytics after ≥1 poll cycle post-migration.
+- Notifications fire at 20% and 5% Fable headroom, once per crossing.
+- Benchmark can measure `claude-fable-5` end to end.
+- No behavior change for accounts without Fable access.

--- a/_bmad-output/planning-artifacts/epics/epic-list.md
+++ b/_bmad-output/planning-artifacts/epics/epic-list.md
@@ -87,3 +87,32 @@ Alex doesn't just hit the wall anymore — when his 5h or 7d plan quota runs out
 
 Alex doesn't just know how much headroom he has — he knows what he's getting for it. By correlating actual token consumption from Claude Code session logs with utilization % changes, cc-hdrm computes a "Tokens per Percent" (TPP) metric that reveals how many tokens it takes to burn 1% of the 5h budget. When Anthropic silently tightens the rate limits, the TPP trend line drops and Alex sees it. An opt-in "Measure" button sends a known-size request for calibrated readings.
 **Stories:** 20.1 Active Benchmark (per-model, token type discovery), 20.2 Log Parser (health indicator), 20.3 Passive TPP Engine (per-model, capped accumulation), 20.4 TPP Visualization (two-tier: benchmark + passive), 20.5 Historical Backfill (nice-to-have)
+
+## Epic 21: Fable Model Usage Tracking (Phase 6)
+
+Alex uses Fable 5 for the hard problems — and it has its own weekly cap, invisible until now. cc-hdrm parses the API's model-scoped limits, shows a Fable utilization row in the popover, persists the history, charts it in analytics, and fires the same 20%/5% headroom alerts Alex already trusts. The TPP benchmark learns Fable's token economics too.
+**Stories:** 21.1 Scoped-limits parsing, 21.2 Popover display, 21.3 Persistence + analytics series, 21.4 Threshold notifications, 21.5 Benchmark default model update (Sprint change proposal 2026-08-12)
+
+## Epic 22: Codex Data Pipeline & API Spike (Phase 7)
+
+Alex uses Codex alongside Claude — cc-hdrm silently finds his Codex credentials in `~/.codex/auth.json` and starts polling his usage. Story 22.1 is a kill-gate spike mirroring the Claude API spike: validate endpoint reachability, document auth, response format, and token refresh. Codex polling runs in its own failure-isolated lane.
+**FRs covered:** FR49, FR50, FR51, FR52, FR60
+**Stories:** 22.1 API Spike (kill gate), 22.2 Codex Credentials Service, 22.3 Codex API Client & Defensive Parsing, 22.4 Codex Polling Lane & Expiry Handling (Sprint change proposal 2026-08-12, Codex)
+
+## Epic 23: Codex Menu Bar & Popover (Phase 7)
+
+Alex glances at a second menu bar item and knows his Codex headroom instantly — same color coding, same weight escalation. Clicking it opens a Codex popover with 5h and weekly ring gauges, countdowns, plan type, credits balance, and slope indicators. The item auto-hides when Codex isn't installed.
+**FRs covered:** FR53, FR54, FR55, FR57 (auto-hide)
+**Stories:** 23.1 Second Status Item & Headroom Display, 23.2 Codex Popover Panel, 23.3 Codex Error & Status States, 23.4 Codex Slope Indicators
+
+## Epic 24: Codex Notifications & Settings (Phase 7)
+
+Alex never hits the Codex wall by surprise — threshold notifications fire for both Codex windows with reset context, and settings let him tune thresholds or switch Codex tracking off entirely.
+**FRs covered:** FR56, FR57
+**Stories:** 24.1 Codex Threshold Notifications, 24.2 Codex Settings Integration
+
+## Epic 25: Codex History & Analytics (Phase 7)
+
+Alex's Codex usage builds the same permanent record his Claude usage does — poll snapshots persisted with a provider dimension, rolled up on the existing tiers, and explorable in the analytics window via provider selection.
+**FRs covered:** FR58, FR59
+**Stories:** 25.1 Provider-Dimension Schema Migration (additive, non-destructive), 25.2 Codex Poll Persistence & Rollups, 25.3 Analytics Provider Integration

--- a/_bmad-output/planning-artifacts/prd.md
+++ b/_bmad-output/planning-artifacts/prd.md
@@ -1,7 +1,9 @@
 ---
 stepsCompleted: [step-01-init, step-02-discovery, step-03-success, step-04-journeys, step-05-domain, step-06-innovation, step-07-project-type, step-08-scoping, step-09-functional, step-10-nonfunctional, step-11-polish, step-e-01-discovery, step-e-02-review, step-e-03-edit]
-lastEdited: '2026-02-10'
+lastEdited: '2026-08-12'
 editHistory:
+  - date: '2026-08-12'
+    changes: 'Added Phase 7 Codex Usage Tracking (FR49-FR60), amended NFR8 endpoint allowlist with chatgpt.com, added NFR14-NFR15 (Codex credential handling, provider failure isolation) per sprint change proposal 2026-08-12 (Codex)'
   - date: '2026-02-10'
     changes: 'Replaced waste terminology with neutral unused capacity framing (FR40, headroom categories), moved extra usage from Phase 4 to Phase 3, added FR46-FR48 for subscription intelligence (pattern detection, total cost comparison, analytics display)'
   - date: '2026-02-03'
@@ -71,29 +73,38 @@ The usage API lives at `https://api.anthropic.com/api/oauth/usage` -- NOT `claud
 ```json
 {
   "five_hour": {
-    "utilization": 18.0,
-    "resets_at": "2026-01-31T01:59:59.782798+00:00"
+    "utilization": 15.0,
+    "resets_at": "2026-08-12T03:40:00.059198+00:00"
   },
   "seven_day": {
-    "utilization": 6.0,
-    "resets_at": "2026-02-06T08:59:59.782818+00:00"
-  },
-  "seven_day_sonnet": {
-    "utilization": 0.0,
-    "resets_at": null
+    "utilization": 67.0,
+    "resets_at": "2026-08-12T22:00:01.059220+00:00"
   },
   "extra_usage": {
     "is_enabled": false,
     "monthly_limit": null,
     "used_credits": null,
     "utilization": null
-  }
+  },
+  "limits": [
+    { "kind": "session", "group": "session", "percent": 15, "severity": "normal",
+      "resets_at": "2026-08-12T03:40:00.059198+00:00", "scope": null, "is_active": false },
+    { "kind": "weekly_all", "group": "weekly", "percent": 67, "severity": "normal",
+      "resets_at": "2026-08-12T22:00:01.059220+00:00", "scope": null, "is_active": true },
+    { "kind": "weekly_scoped", "group": "weekly", "percent": 63, "severity": "normal",
+      "resets_at": "2026-08-12T22:00:00.059415+00:00",
+      "scope": { "model": { "id": null, "display_name": "Fable" }, "surface": null },
+      "is_active": false }
+  ]
 }
 ```
 
 - `utilization` -- percentage (0-100)
 - `resets_at` -- ISO 8601 timestamp or null
-- Additional fields: `seven_day_oauth_apps`, `seven_day_opus`, `seven_day_cowork`, `iguana_necktie` (all nullable)
+- `limits` (added 2026-08) -- array of limit entries: `kind` (`session`, `weekly_all`, `weekly_scoped`), `percent`, `severity`, `resets_at`, `is_active`, and `scope.model.display_name` for model-scoped caps (e.g. Fable's 50%-of-weekly cap). Source of truth for per-model tracking (Epic 21).
+- Legacy per-model windows `seven_day_sonnet`, `seven_day_opus` now return `null` -- superseded by `weekly_scoped` entries in `limits`.
+- Additional fields (all nullable, unparsed): `seven_day_oauth_apps`, `seven_day_cowork`, `spend` (usage-credits object), extended `extra_usage` fields (`daily`, `weekly`, `currency`), plus obfuscated experiment fields (`iguana_necktie`, `nimbus_quill`, ...)
+- Window objects also carry `limit_dollars` / `used_dollars` / `remaining_dollars` (null on subscription plans)
 
 ### Token Refresh
 
@@ -233,9 +244,25 @@ Replaces the original "limit prediction" concept. Explicit time-to-exhaustion pr
 
 ### Phase 4: Future
 
-- Sonnet-specific usage breakdown (API returns `seven_day_sonnet` data)
+- ~~Sonnet-specific usage breakdown~~ -- Superseded by Epic 21 model-scoped limit tracking (API moved per-model windows to the `limits` array; `seven_day_sonnet` now null). Sprint change proposal 2026-08-12.
 - Linux tray support
 - ~~Extra usage / spending tracking~~ -- Moved to Phase 3 / Epic 16 (data already available and persisted via PR 43)
+- Codex Token Efficiency Ratio, unused-capacity breakdown, tier recommendation (deferred from Phase 7)
+
+### Phase 7: Codex Usage Tracking
+
+Extend cc-hdrm to monitor OpenAI Codex subscription limits alongside Claude, with full feature parity for core tracking: dedicated menu bar item, popover panel, threshold notifications, historical persistence, and analytics integration. (Sprint change proposal 2026-08-12, Codex.)
+
+**Kill Condition:** If the Codex usage endpoint cannot be reached from a standalone macOS process using `~/.codex/auth.json` credentials, Phase 7 is killed (spike story 22.1).
+
+**Data source (to be validated by spike):**
+
+- Credentials: `~/.codex/auth.json` (or `$CODEX_HOME/auth.json`), JWT claims carry plan type
+- Usage: `GET https://chatgpt.com/backend-api/wham/usage` -- `rate_limit.primary_window` (5h session), `rate_limit.secondary_window` (weekly), `additional_rate_limits[]`, credits (balance / hasCredits / unlimited)
+- Credits inventory: `GET https://chatgpt.com/backend-api/wham/rate-limit-reset-credits`
+- Token refresh: mechanism TBD in spike
+
+**Deferred beyond Phase 7:** Codex TPP, Codex unused-capacity breakdown, Codex tier recommendation.
 
 ### Risk Mitigation
 
@@ -416,6 +443,21 @@ Without cc-hdrm, he'd have kept going, gotten cut off mid-response, lost context
 - FR47: Tier recommendation computes total cost (base subscription + extra usage charges) when comparing tiers
 - FR48: Analytics displays total cost breakdown when extra usage data is available
 
+### Codex Usage Tracking (Phase 7)
+
+- FR49: App can read Codex OAuth credentials from `~/.codex/auth.json` (or `$CODEX_HOME/auth.json`) without user interaction, read-only
+- FR50: App can detect the user's Codex plan type from stored credentials
+- FR51: App can fetch current Codex usage data (5h primary window, weekly secondary window, credits) from the ChatGPT backend usage endpoint
+- FR52: App can detect expired/invalid Codex credentials and display an actionable status message ("run codex to refresh" or equivalent validated by spike)
+- FR53: User can see Codex 5h headroom in a dedicated second menu bar item with the same color/weight coding as Claude
+- FR54: User can click the Codex menu bar item to expand a Codex panel with 5h and weekly gauges, reset countdowns, plan type, and credits balance when available
+- FR55: User can see per-window slope indicators for Codex (menu bar + popover), reusing the 4-level slope model
+- FR56: User can receive threshold notifications for Codex 5h and weekly windows at configurable headroom thresholds
+- FR57: User can enable/disable Codex tracking in settings; the Codex menu bar item auto-hides when no credentials are found or tracking is disabled
+- FR58: App persists Codex poll snapshots to SQLite with a provider dimension, participating in the existing tiered rollup strategy
+- FR59: User can view Codex historical data in the analytics window via provider selection
+- FR60: Codex polling failures degrade gracefully and independently -- Claude tracking is never affected by Codex errors, and vice versa
+
 ## Non-Functional Requirements
 
 ### Performance
@@ -430,7 +472,9 @@ Without cc-hdrm, he'd have kept going, gotten cut off mid-response, lost context
 
 - NFR6: OAuth credentials are read from Keychain at runtime and never persisted to disk, logs, or user defaults
 - NFR7: OAuth tokens are read fresh from Keychain each poll cycle and not cached in application state between cycles
-- NFR8: No credentials or usage data are transmitted to any endpoint other than `api.anthropic.com` (usage data) and `platform.claude.com` (token refresh)
+- NFR8: No credentials or usage data are transmitted to any endpoint other than `api.anthropic.com` (Claude usage), `platform.claude.com` (Claude token refresh), and `chatgpt.com` (Codex usage; plus the Codex token-refresh endpoint documented by the Phase 7 spike)
+- NFR14: Codex credentials are read from `auth.json` fresh each poll cycle, never written back, never persisted elsewhere, and never logged
+- NFR15: Claude and Codex polling lanes are failure-isolated -- an error in one provider's pipeline must not affect the other's display, notifications, or persistence
 - NFR9: API requests use HTTPS exclusively
 
 ### Integration

--- a/_bmad-output/planning-artifacts/sprint-change-proposal-2026-08-12-codex.md
+++ b/_bmad-output/planning-artifacts/sprint-change-proposal-2026-08-12-codex.md
@@ -1,0 +1,309 @@
+# Sprint Change Proposal — OpenAI Codex Usage Tracking
+
+**Date:** 2026-08-12
+**Author:** Boss (facilitated by SM / correct-course workflow)
+**Status:** APPROVED 2026-08-12 — edits applied to PRD, epic list, and sprint status
+**Mode:** Batch review
+**Scope classification:** Moderate (backlog addition, new phase; architecture addendum required)
+
+> Numbering note: Epic 21 is taken by the concurrent Fable Model Usage Tracking proposal
+> (sprint-change-proposal-2026-08-12-fable.md). This proposal uses Epics 22–25.
+
+---
+
+## Section 1: Issue Summary
+
+### Problem Statement
+
+cc-hdrm tracks only Claude subscription usage. The user also runs OpenAI Codex, which has an analogous rate-limit system (5-hour primary window + weekly secondary window + purchasable credits) and the same pain: no passive, always-visible way to monitor headroom. The user must run `/status` inside the Codex TUI to see limits — exactly the workflow interruption cc-hdrm was built to eliminate for Claude.
+
+### Discovery Context
+
+- New stakeholder requirement (2026-08-12), not triggered by an in-flight story. All epics 1–21 are done or (Epic 21) separately proposed; this change is independent of the Fable epic.
+- Decision inputs gathered at workflow start:
+  - **Scope:** Full parity with Claude tracking (menu bar, notifications, history, analytics).
+  - **Kill gate:** API spike story first, mirroring the 2026-01-31 Claude spike.
+  - **Menu bar model:** Two separate status items (Claude and Codex), each with its own popover.
+  - **Review mode:** Batch.
+
+### Evidence of Feasibility
+
+- Codex CLI stores OAuth credentials on disk at `~/.codex/auth.json` (or `$CODEX_HOME/auth.json`), including JWT claims with email and plan type.
+- Usage endpoint: `GET https://chatgpt.com/backend-api/wham/usage` with `Authorization: Bearer <token>`. Response contains `rate_limit.primary_window` (session/5h) and `rate_limit.secondary_window` (weekly), `additional_rate_limits[]` (per-model), and credits fields (balance, hasCredits, unlimited).
+- Credit inventory endpoint: `GET https://chatgpt.com/backend-api/wham/rate-limit-reset-credits`.
+- Prior art: CodexBar (steipete/CodexBar) is a shipping macOS menu bar app reading exactly this surface — the approach is proven.
+- **Caveat:** these are undocumented internal endpoints (same risk class as Claude's `api/oauth/usage`). Paths, fields, and access rules may change. Token refresh mechanism and endpoint must be validated in the spike.
+
+---
+
+## Section 2: Impact Analysis
+
+### Epic Impact
+
+| Area | Impact |
+| --- | --- |
+| Epics 1–20 | **None.** All done; no rollback, no modification. Change is purely additive. |
+| Epic 21 (Fable) | **None.** Independent scope (Claude API's model-scoped limits vs. a new provider). No shared files beyond the usual planning artifacts. |
+| New epics | Four new epics (22–25) forming **Phase 7: Codex Usage Tracking**. |
+| Sequencing | Epic 22 (spike + pipeline) gates everything. 23 → 24/25 after. 24 and 25 are independent of each other. Phase 7 has no dependency on Epic 21 and can run before, after, or parallel to it. |
+| Kill gate | Story 22.1 spike. If the usage endpoint cannot be reached from a standalone macOS process with `auth.json` tokens, Phase 7 is killed and Epics 23–25 are cancelled. |
+
+### Story Impact
+
+- No existing stories change. All new stories (see Section 4).
+- Reuse-heavy: `PollingEngine` pattern, `NotificationService` threshold state machines, `SlopeCalculationService`, SQLite rollup engine, gauge/popover components are all designed as reusable layers.
+
+### Artifact Conflicts
+
+| Artifact | Conflict | Resolution |
+| --- | --- | --- |
+| PRD | Claude-only framing; FR list ends at FR48; **NFR8 forbids transmission to any endpoint other than `api.anthropic.com`, `platform.claude.com`** (+`api.github.com` in project-context) | Add Phase 7 section, FR49–FR60, amend NFR8, add NFR14–NFR15 |
+| Architecture | No provider concept; boundaries table maps one API client to one host; SQLite schema has no provider dimension | Phase 7 architecture addendum (new services, second status item, schema migration) |
+| UX spec | Single menu bar item, single popover | Codex addendum: second status item + mirrored popover layout |
+| project-context.md | Integrations, boundaries, and constraint 3 (endpoint allowlist) are Claude-only | Update after Epic 22 lands (implementation-time task, not proposal-time) |
+| sprint-status.yaml | No Phase 7 entries; concurrent Fable branch also appends here | Add epics 22–25 with status `backlog` upon approval, appended after the Fable block (shared-resource rule: each branch touches only its own entries) |
+| Entitlements / sandbox | App must read `~/.codex/auth.json` from disk | Validate in spike 22.1. **`cc_hdrm.entitlements` is a protected file** — any change requires explicit user instruction |
+
+### Technical Impact
+
+- **New network host:** `chatgpt.com` (+ token-refresh host, TBD in spike — likely `auth.openai.com`). Security posture (NFR8-style allowlist) must be explicitly widened, not silently.
+- **Credentials on disk, not Keychain:** different threat model. Read-only file access; never write to `auth.json`; never log tokens (extends existing logging rule).
+- **Two polling lanes:** Codex polling must fail independently — a Codex outage must never degrade Claude display, and vice versa.
+- **SQLite migration:** provider dimension for historical data. Migration must preserve all existing Claude history (lesson from Story 17.5: never destroy rollup history).
+- **Naming:** "cc-hdrm" reads as Claude-Code-specific. Out of scope for this change; noted for future consideration.
+
+### Explicitly Deferred (not in Phase 7)
+
+| Item | Why deferred |
+| --- | --- |
+| Codex Token Efficiency Ratio (TPP) | TPP depends on parsing Claude Code session logs; Codex equivalent needs its own log-format research. Separate epic if wanted. |
+| Codex unused-capacity three-band breakdown (FR40-style) | Requires validated credit-math for Codex windows; revisit after spike + real poll data exist. |
+| Codex tier recommendation / subscription intelligence | Requires Codex pricing model research; premature before basic tracking ships. |
+
+---
+
+## Section 3: Recommended Approach
+
+**Selected path: Option 1 — Direct Adjustment (additive epics).**
+
+| Option | Verdict | Rationale |
+| --- | --- | --- |
+| 1. Direct Adjustment | **Selected** | Backlog holds only the independent Fable epic; change is purely additive; existing architecture layers were built for reuse. Effort: High (full parity). Risk: Medium (undocumented API — mitigated by kill-gate spike). |
+| 2. Rollback | Not viable | Nothing to roll back; no completed work conflicts. |
+| 3. MVP Review | Not viable | MVP shipped long ago; this is post-MVP expansion, not scope reduction. |
+
+**Risk assessment:**
+
+| Risk | Likelihood | Impact | Mitigation |
+| --- | --- | --- | --- |
+| Codex endpoint unreachable outside ChatGPT web context (Cloudflare/CORS/device checks) | Medium | Fatal to phase | Spike 22.1 kill gate before any UI work |
+| OpenAI changes undocumented API | Medium | Medium | Defensive parsing (all fields optional), graceful degradation — same pattern as Claude |
+| Token refresh semantics unknown | Medium | Medium | Spike documents refresh; fallback UX: "run codex to refresh" status (mirrors Claude token-expiry UX) |
+| SQLite migration corrupts Claude history | Low | High | Additive migration only; no destructive DDL; migration test against copy of real DB |
+| Menu bar clutter (two items) | Low | Low | User-chosen; Codex item auto-hides when no `auth.json` present or tracking disabled |
+
+**Timeline impact:** No existing commitments affected. Phase 7 is new work, roughly comparable in size to Phase 3 (epics 10–13).
+
+---
+
+## Section 4: Detailed Change Proposals
+
+### 4.1 PRD (`_bmad-output/planning-artifacts/prd.md`)
+
+**Edit 1 — Phase list: add Phase 7 after Phase 4 section.**
+
+NEW:
+
+```markdown
+### Phase 7: Codex Usage Tracking
+
+Extend cc-hdrm to monitor OpenAI Codex subscription limits alongside Claude, with full
+feature parity for core tracking: dedicated menu bar item, popover panel, threshold
+notifications, historical persistence, and analytics integration.
+
+**Kill Condition:** If the Codex usage endpoint cannot be reached from a standalone
+macOS process using `~/.codex/auth.json` credentials, Phase 7 is killed (spike story 22.1).
+
+**Data source (to be validated by spike):**
+- Credentials: `~/.codex/auth.json` (or `$CODEX_HOME/auth.json`), JWT claims carry plan type
+- Usage: `GET https://chatgpt.com/backend-api/wham/usage` — `rate_limit.primary_window`
+  (5h session), `rate_limit.secondary_window` (weekly), `additional_rate_limits[]`,
+  credits (balance / hasCredits / unlimited)
+- Credits inventory: `GET https://chatgpt.com/backend-api/wham/rate-limit-reset-credits`
+- Token refresh: mechanism TBD in spike
+
+**Deferred beyond Phase 7:** Codex TPP, Codex unused-capacity breakdown, Codex tier
+recommendation.
+```
+
+**Edit 2 — Functional Requirements: append new section.**
+
+NEW:
+
+```markdown
+### Codex Usage Tracking (Phase 7)
+
+- FR49: App can read Codex OAuth credentials from `~/.codex/auth.json` (or `$CODEX_HOME/auth.json`) without user interaction, read-only
+- FR50: App can detect the user's Codex plan type from stored credentials
+- FR51: App can fetch current Codex usage data (5h primary window, weekly secondary window, credits) from the ChatGPT backend usage endpoint
+- FR52: App can detect expired/invalid Codex credentials and display an actionable status message ("run codex to refresh" or equivalent validated by spike)
+- FR53: User can see Codex 5h headroom in a dedicated second menu bar item with the same color/weight coding as Claude
+- FR54: User can click the Codex menu bar item to expand a Codex panel with 5h and weekly gauges, reset countdowns, plan type, and credits balance when available
+- FR55: User can see per-window slope indicators for Codex (menu bar + popover), reusing the 4-level slope model
+- FR56: User can receive threshold notifications for Codex 5h and weekly windows at configurable headroom thresholds
+- FR57: User can enable/disable Codex tracking in settings; the Codex menu bar item auto-hides when no credentials are found or tracking is disabled
+- FR58: App persists Codex poll snapshots to SQLite with a provider dimension, participating in the existing tiered rollup strategy
+- FR59: User can view Codex historical data in the analytics window via provider selection
+- FR60: Codex polling failures degrade gracefully and independently — Claude tracking is never affected by Codex errors, and vice versa
+```
+
+**Edit 3 — Non-Functional Requirements: amend NFR8, add NFR14–NFR15.**
+
+OLD:
+
+```markdown
+- NFR8: No credentials or usage data are transmitted to any endpoint other than `api.anthropic.com` (usage data) and `platform.claude.com` (token refresh)
+```
+
+NEW:
+
+```markdown
+- NFR8: No credentials or usage data are transmitted to any endpoint other than `api.anthropic.com` (Claude usage), `platform.claude.com` (Claude token refresh), and `chatgpt.com` (Codex usage; plus the Codex token-refresh endpoint documented by the Phase 7 spike)
+- NFR14: Codex credentials are read from `auth.json` fresh each poll cycle, never written back, never persisted elsewhere, and never logged
+- NFR15: Claude and Codex polling lanes are failure-isolated — an error in one provider's pipeline must not affect the other's display, notifications, or persistence
+```
+
+**Edit 4 — Phase 4: Future list: append deferred Codex items.**
+
+NEW (appended to existing list):
+
+```markdown
+- Codex Token Efficiency Ratio, unused-capacity breakdown, tier recommendation (deferred from Phase 7)
+```
+
+### 4.2 Epic List (`_bmad-output/planning-artifacts/epics/epic-list.md`)
+
+**Edit 5 — append four new epics after Epic 21.**
+
+NEW:
+
+```markdown
+## Epic 22: Codex Data Pipeline & API Spike (Phase 7)
+
+Alex uses Codex alongside Claude — cc-hdrm silently finds his Codex credentials in
+`~/.codex/auth.json` and starts polling his usage. Story 22.1 is a kill-gate spike
+mirroring the Claude API spike: validate endpoint reachability, document auth,
+response format, and token refresh. Codex polling runs in its own failure-isolated lane.
+**FRs covered:** FR49, FR50, FR51, FR52, FR60
+**Stories:** 22.1 API Spike (kill gate), 22.2 Codex Credentials Service, 22.3 Codex API
+Client & Defensive Parsing, 22.4 Codex Polling Lane & Expiry Handling
+
+## Epic 23: Codex Menu Bar & Popover (Phase 7)
+
+Alex glances at a second menu bar item and knows his Codex headroom instantly — same
+color coding, same weight escalation. Clicking it opens a Codex popover with 5h and
+weekly ring gauges, countdowns, plan type, credits balance, and slope indicators.
+The item auto-hides when Codex isn't installed.
+**FRs covered:** FR53, FR54, FR55, FR57 (auto-hide)
+**Stories:** 23.1 Second Status Item & Headroom Display, 23.2 Codex Popover Panel,
+23.3 Codex Error & Status States, 23.4 Codex Slope Indicators
+
+## Epic 24: Codex Notifications & Settings (Phase 7)
+
+Alex never hits the Codex wall by surprise — threshold notifications fire for both
+Codex windows with reset context, and settings let him tune thresholds or switch
+Codex tracking off entirely.
+**FRs covered:** FR56, FR57
+**Stories:** 24.1 Codex Threshold Notifications, 24.2 Codex Settings Integration
+
+## Epic 25: Codex History & Analytics (Phase 7)
+
+Alex's Codex usage builds the same permanent record his Claude usage does — poll
+snapshots persisted with a provider dimension, rolled up on the existing tiers, and
+explorable in the analytics window via provider selection.
+**FRs covered:** FR58, FR59
+**Stories:** 25.1 Provider-Dimension Schema Migration (additive, non-destructive),
+25.2 Codex Poll Persistence & Rollups, 25.3 Analytics Provider Integration
+```
+
+### 4.3 Sprint Status (`_bmad-output/implementation-artifacts/sprint-status.yaml`)
+
+**Edit 6 — append Phase 7 entries after the Fable block.**
+
+NEW:
+
+```yaml
+  # Sprint Change Proposal 2026-08-12 (Codex) — Phase 7
+  epic-22: backlog  # Codex Data Pipeline & API Spike — 22.1 is kill gate for Phase 7
+  22-1-codex-api-spike: backlog
+  22-2-codex-credentials-service: backlog
+  22-3-codex-api-client-defensive-parsing: backlog
+  22-4-codex-polling-lane-expiry-handling: backlog
+
+  epic-23: backlog  # Codex Menu Bar & Popover
+  23-1-second-status-item-headroom-display: backlog
+  23-2-codex-popover-panel: backlog
+  23-3-codex-error-status-states: backlog
+  23-4-codex-slope-indicators: backlog
+
+  epic-24: backlog  # Codex Notifications & Settings
+  24-1-codex-threshold-notifications: backlog
+  24-2-codex-settings-integration: backlog
+
+  epic-25: backlog  # Codex History & Analytics
+  25-1-provider-dimension-schema-migration: backlog
+  25-2-codex-poll-persistence-rollups: backlog
+  25-3-analytics-provider-integration: backlog
+```
+
+### 4.4 Architecture (`_bmad-output/planning-artifacts/architecture.md`)
+
+**Edit 7 — Phase 7 addendum (summary; full addendum authored when Epic 22 spike results land, same pattern as prior phases).**
+
+Key decisions to record:
+
+- **New services:** `CodexCredentialsService` (only component reading `~/.codex/auth.json`), `CodexAPIClient` (only component calling `chatgpt.com`). Token refresh service only if the spike proves refresh is needed and feasible.
+- **No premature provider abstraction.** Codex services are concrete siblings of the Claude services. A shared `Provider` protocol is introduced only if/when a third provider appears.
+- **Polling:** second independent polling loop (own `Task`, own error mapping to a Codex-specific connection status in `AppState`). Failure isolation per NFR15.
+- **State:** `AppState` gains a Codex section (usage, connection status, plan) — same one-way flow, services write via methods, views read-only.
+- **UI:** second `NSStatusItem` with its own popover, reusing gauge/countdown/status-message components. Auto-hide when no credentials or disabled.
+- **Persistence:** additive SQLite migration adding provider dimension. **Non-destructive** — existing Claude rows untouched (Story 17.5 lesson). Rollup engine parameterized by provider.
+- **Boundaries table additions:**
+
+| Boundary | Owner Component | Rule |
+| --- | --- | --- |
+| Codex credentials file | `CodexCredentialsService` | Only component reading `auth.json`; read-only |
+| HTTP (Codex usage) | `CodexAPIClient` | Only component calling `chatgpt.com` |
+
+### 4.5 UX Specification
+
+**Edit 8 — Codex addendum (authored during Epic 23, informed by spike data):**
+
+- Second menu bar item: distinct glyph (Claude keeps `✳`; Codex gets its own symbol — decided in 23.1) with identical color/weight escalation from `HeadroomState`.
+- Codex popover mirrors Claude popover layout: 5h ring + weekly ring, countdowns, plan/freshness footer, credits line when credits exist.
+- Both popovers reuse existing accessibility patterns (triple-encoded state: number + color + weight).
+
+---
+
+## Section 5: Implementation Handoff
+
+**Scope classification: Moderate** — backlog reorganization (new phase, four epics), plus an architecture addendum. No fundamental replan: existing goals, MVP, and completed work are untouched.
+
+| Role | Responsibility |
+| --- | --- |
+| SM (create-story workflow) | Create Story 22.1 first via `/bmad-bmm-create-story`; subsequent stories follow the standard BMAD lifecycle one at a time |
+| Dev (dev-story workflow) | Implement 22.1 spike; report kill-gate verdict before any further Phase 7 story is created |
+| Architect | Author the Phase 7 architecture addendum after spike results (endpoint, refresh, sandbox/entitlement findings) |
+| User (Boss) | Kill/go decision on spike results; explicit instruction required if entitlements changes turn out to be needed |
+
+**Sequencing & gates:**
+
+1. Approve this proposal → update `sprint-status.yaml` + PRD + epic list.
+2. Epic 22, Story 22.1 spike → **kill gate**. Go: continue. Kill: cancel epics 22–25, revert PRD Phase 7 to a "investigated, not feasible" note.
+3. Epic 22 remainder → Epic 23 → Epics 24 and 25 (either order, independent).
+
+**Success criteria:**
+
+- Spike documents: auth format, endpoint contract, response schema, refresh mechanism, sandbox/file-access findings.
+- Codex tracking meets the same bars as Claude: <60s staleness, failure isolation, zero false-negative notifications, no credential leakage to logs/disk.
+- Claude functionality fully unaffected (regression: existing test suite stays green).

--- a/_bmad-output/planning-artifacts/sprint-change-proposal-2026-08-12-fable.md
+++ b/_bmad-output/planning-artifacts/sprint-change-proposal-2026-08-12-fable.md
@@ -1,0 +1,214 @@
+# Sprint Change Proposal — Fable Model Usage Tracking
+
+**Date:** 2026-08-12
+**Author:** Correct Course workflow (SM)
+**Status:** Approved 2026-08-12
+**Change scope classification:** Minor–Moderate (new epic, no rework of existing stories)
+
+---
+
+## 1. Issue Summary
+
+**Anthropic released Claude Fable 5 and cc-hdrm cannot see it.** Fable usage is
+tracked against a separate model-scoped weekly cap (50% of the weekly limit on
+Max plans). cc-hdrm shows only the 5h and 7d overall windows, so a user can hit
+the Fable wall with the app reporting healthy headroom.
+
+**Discovery context:** User request, 2026-08-12. Not triggered by a story —
+all epics (1–20) are done. Category: new requirement from a market change.
+
+**Evidence (live `/api/oauth/usage` capture, 2026-08-12, this account):**
+
+- The API response gained a new `limits` array. The Fable cap appears as:
+
+```json
+{
+  "kind": "weekly_scoped",
+  "group": "weekly",
+  "percent": 63,
+  "severity": "normal",
+  "resets_at": "2026-08-12T22:00:00.059415+00:00",
+  "scope": { "model": { "id": null, "display_name": "Fable" }, "surface": null },
+  "is_active": false
+}
+```
+
+- This account showed **Fable at 63%** while the overall weekly window was at
+  67% — the two run independently. The gap is invisible in today's UI.
+- The legacy model windows (`seven_day_sonnet`, `seven_day_opus`) are now
+  `null` — model-scoped tracking has moved to the `limits` array. The
+  `sevenDaySonnet` field parsed in `cc-hdrm/Models/UsageResponse.swift` is dead.
+- The response also gained a `spend` object (usage credits) and extra fields on
+  `extra_usage` (`daily`, `weekly`, `currency`). Out of scope here, but the PRD
+  API documentation must record them.
+- Plan structure (Anthropic help center): Max plans — Fable capped at 50% of
+  the weekly allowance, shared pool. Pro plans — Fable runs on pay-as-you-go
+  usage credits.
+
+---
+
+## 2. Impact Analysis
+
+### Epic impact
+
+- **No in-flight work.** Epics 1–20 are all `done` in sprint-status.yaml.
+  Nothing is invalidated, blocked, or resequenced.
+- **New epic needed: Epic 21 — Fable Model Usage Tracking (Phase 6).**
+  Mirrors the shape of Epic 17 (Extra Usage): state → popover → analytics →
+  alerts.
+- **Epic 20 (TPP) needs no rework.** The TPP pipeline is model-agnostic —
+  Fable tokens from Claude Code session logs already flow through
+  `ClaudeCodeLogParser` → `PassiveTPPEngine` keyed by model string. Only the
+  benchmark default model list needs a one-line update.
+
+### Artifact conflicts
+
+| Artifact | Impact |
+|---|---|
+| PRD (`prd.md`) | API response section is stale (no `limits`, no `spend`, legacy model windows now null). Phase 4 future item "Sonnet-specific usage breakdown" is superseded. |
+| Epic list (`epics/epic-list.md`) | Needs Epic 21 entry. |
+| Architecture (`architecture.md`) | Data model addition: `limits` parsing, one SQLite schema migration (2 columns). No component or pattern changes. |
+| UX spec | Popover gains one Fable utilization row; analytics gains one series toggle. Follows existing patterns — no new interaction design. |
+| sprint-status.yaml | Add epic-21 + 5 story entries as `backlog` after approval. |
+
+### Technical impact
+
+- `cc-hdrm/Models/UsageResponse.swift` — add `limits` array decoding; remove
+  dead `sevenDaySonnet`.
+- `cc-hdrm/Models/UsagePoll.swift`, `Services/DatabaseManager.swift`,
+  `Services/HistoricalDataService.swift` — persist Fable weekly utilization +
+  reset time (schema migration, additive columns only).
+- `Views/` popover + analytics — display work, existing component patterns.
+- `Services/NotificationService.swift` — threshold checks for the scoped
+  window, same 20%/5% model as existing windows.
+- `Views/BenchmarkSectionView.swift:33` — add `claude-fable-5` to
+  `defaultModels`.
+
+---
+
+## 3. Recommended Approach
+
+**Direct Adjustment — add Epic 21 with 5 stories.** (Option 1)
+
+- **Rollback:** Not applicable — nothing to revert.
+- **MVP review:** Not applicable — MVP shipped; this is post-MVP scope.
+
+**Rationale:** The change is purely additive. The API already serves the data;
+the app's window-display, persistence, notification, and benchmark patterns
+all have precedents (Epics 3, 5, 10, 17, 20) to copy. Parsing the `limits`
+array generically (keyed by `scope.model.display_name` from the API, no
+hardcoded model names) means future model-scoped caps appear without code
+changes.
+
+- **Effort:** Low–Medium (5 small stories, one additive schema migration)
+- **Risk:** Low (additive; every feature degrades to "not shown" when the
+  scoped limit is absent from the response)
+- **Timeline impact:** None on existing work.
+
+---
+
+## 4. Detailed Change Proposals
+
+### 4.1 PRD — API response documentation
+
+**Section:** Claude API response example + field notes
+
+**OLD:** JSON example with `five_hour`, `seven_day`, `seven_day_sonnet`,
+`extra_usage`; note listing `seven_day_oauth_apps`, `seven_day_opus`,
+`seven_day_cowork` as additional nullable fields.
+
+**NEW:** Updated 2026-08 example including the `limits` array (kinds:
+`session`, `weekly_all`, `weekly_scoped` with `scope.model.display_name`),
+the `spend` object, and extended `extra_usage` fields. Note that legacy
+`seven_day_<model>` windows now return `null` and are superseded by
+`weekly_scoped` limits entries.
+
+**Rationale:** PRD is the API reference for future stories; it currently
+documents a response shape the API no longer returns.
+
+### 4.2 PRD — Phase 4 future list
+
+**OLD:** `- Sonnet-specific usage breakdown (API returns seven_day_sonnet data)`
+
+**NEW:** `- ~~Sonnet-specific usage breakdown~~ — Superseded by Epic 21
+model-scoped limit tracking (API moved per-model windows to the limits array)`
+
+### 4.3 Epic list — new Epic 21 entry
+
+**NEW (append to `epics/epic-list.md`):**
+
+> ## Epic 21: Fable Model Usage Tracking (Phase 6)
+>
+> Alex uses Fable 5 for the hard problems — and it has its own weekly cap,
+> invisible until now. cc-hdrm parses the API's model-scoped limits, shows a
+> Fable utilization row in the popover, persists the history, charts it in
+> analytics, and fires the same 20%/5% headroom alerts Alex already trusts.
+> The TPP benchmark learns Fable's token economics too.
+> **Stories:** 21.1 Scoped-limits parsing, 21.2 Popover display, 21.3
+> Persistence + analytics series, 21.4 Threshold notifications, 21.5
+> Benchmark default model update
+
+### 4.4 New epic document — `epics/epic-21-fable-model-usage-tracking.md`
+
+Created via `/bmad-bmm-create-story` per story; epic doc summarizes:
+
+- **Story 21.1 — Scoped limits parsing & domain model.**
+  Decode the `limits` array in `cc-hdrm/Models/UsageResponse.swift`
+  (generic: `kind`, `group`, `percent`, `severity`, `resets_at`,
+  `scope.model.display_name`, `is_active`). Surface `weekly_scoped` entries
+  in the domain layer. Remove dead `sevenDaySonnet`. AC: Fable percent +
+  reset time available to views; absent limits → nil, no crash.
+- **Story 21.2 — Popover Fable utilization display.**
+  Row/gauge in the detailed panel showing scoped-limit utilization, labeled
+  with the API's `display_name`, with reset countdown. Hidden when absent.
+- **Story 21.3 — Persistence & analytics series.**
+  Additive migration: `fable_weekly_util REAL`, `fable_weekly_resets_at
+  INTEGER` on `usage_snapshots` (+ rollup aggregates), following the Epic 17
+  extra-usage column precedent. Analytics window gains a Fable series toggle.
+- **Story 21.4 — Fable threshold notifications.**
+  20%/5% headroom notifications for the scoped window via
+  `Services/NotificationService.swift`, independent dedup per window,
+  respecting existing threshold preferences.
+- **Story 21.5 — Benchmark default model update.**
+  Add `claude-fable-5` to `defaultModels` in
+  `Views/BenchmarkSectionView.swift`. Verify `BenchmarkService` request path
+  works with the Fable model ID. Note in UI copy that Fable benchmarks burn
+  the Fable cap (user opted in knowingly — benchmark remains opt-in Measure
+  button).
+
+### 4.5 Architecture — data model note
+
+Add to the data model section: `limits` array parsing (generic scoped-limit
+struct), schema migration bumping user_version, additive columns only.
+No new services, no new patterns.
+
+### 4.6 sprint-status.yaml
+
+**NEW (after approval):**
+
+```yaml
+  epic-21: backlog  # Fable Model Usage Tracking (Phase 6) — Sprint change proposal 2026-08-12
+  21-1-scoped-limits-parsing-domain-model: backlog
+  21-2-popover-fable-utilization-display: backlog
+  21-3-fable-persistence-analytics-series: backlog
+  21-4-fable-threshold-notifications: backlog
+  21-5-benchmark-default-model-update: backlog
+```
+
+---
+
+## 5. Implementation Handoff
+
+- **Scope classification: Minor** — direct implementation by the dev team via
+  the standard BMAD story lifecycle. No backlog reorganization, no replan.
+- **Handoff:** SM runs `/bmad-bmm-create-story` for 21.1 → dev-story →
+  code-review → PR → merge, then repeats. Stories 21.1 → 21.2 → 21.3 → 21.4
+  are sequential (each builds on the parsed domain data); 21.5 is independent
+  and can run any time.
+- **Success criteria:**
+  - Popover shows Fable utilization + reset countdown when the API reports a
+    scoped weekly limit; shows nothing when it doesn't.
+  - Fable history appears in analytics after ≥1 poll cycle post-migration.
+  - Notifications fire at 20% and 5% Fable headroom, once per crossing.
+  - Benchmark can measure `claude-fable-5` end to end.
+  - No behavior change for accounts without Fable access.

--- a/cc-hdrmTests/Services/TPPChartDataServiceTests.swift
+++ b/cc-hdrmTests/Services/TPPChartDataServiceTests.swift
@@ -165,7 +165,9 @@ struct TPPChartDataServiceTests {
         let storage = MockChartTPPStorage()
         let service = TPPChartDataService(tppStorage: storage)
 
-        let baseDayMs = nowMs - oneDayMs
+        // Anchor at noon yesterday so all 5 hourly points stay in one calendar day
+        let yesterdayNoon = Calendar.current.startOfDay(for: Date().addingTimeInterval(-86_400)).addingTimeInterval(12 * 3_600)
+        let baseDayMs = Int64(yesterdayNoon.timeIntervalSince1970 * 1000)
         let measurements = (0..<5).map { i in
             makeMeasurement(
                 timestamp: baseDayMs + Int64(i) * oneHourMs,


### PR DESCRIPTION
Fixes a flaky test in TPPChartDataServiceTests.

- The daily-average test anchored its 5 hourly points at now minus one day.
- Within 4 hours of midnight, the points spanned two calendar days.
- That produced 2 buckets instead of 1 and failed the averages assertion.
- The fixture now anchors at noon yesterday via Calendar.startOfDay, so the points never cross midnight.
- No production code changed. Sibling tests were checked; none share the hazard.

Verified locally: all 11 tests in the suite pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added planning documentation for Fable model usage tracking, including scoped limits, usage visibility, persistence, notifications, analytics, and benchmark support.
  * Added Codex tracking plans covering credential discovery, usage polling, menu bar visibility, notifications, settings, history, and analytics.
  * Updated product requirements, epic lists, sprint planning, and implementation status for upcoming capabilities.

* **Tests**
  * Improved daily-average chart test coverage by using calendar-day-aligned measurements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->