### PR TITLE
[patch] feat: show app name and version in popover top-left corner

### DIFF
--- a/cc-hdrm/Info.plist
+++ b/cc-hdrm/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.5.0</string>
+	<string>1.6.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>

--- a/cc-hdrm/Info.plist
+++ b/cc-hdrm/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.0</string>
+	<string>1.5.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>

--- a/cc-hdrm/Views/PopoverView.swift
+++ b/cc-hdrm/Views/PopoverView.swift
@@ -14,8 +14,25 @@ struct PopoverView: View {
     var onSignIn: (() -> Void)?
     var onSignOut: (() -> Void)?
 
+    /// "cc-hdrm 1.5.0" — name and version from the bundle, shown in the top-left corner.
+    var appNameAndVersion: String {
+        let info = Bundle.main.infoDictionary
+        let name = info?["CFBundleName"] as? String ?? "cc-hdrm"
+        let version = info?["CFBundleShortVersionString"] as? String ?? ""
+        return version.isEmpty ? name : "\(name) \(version)"
+    }
+
     var body: some View {
         VStack(spacing: 0) {
+            HStack {
+                Text(appNameAndVersion)
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                Spacer()
+            }
+            .padding(.horizontal)
+            .padding(.top, 2)
+
             switch appState.oauthState {
             case .unauthenticated:
                 unauthenticatedView

--- a/cc-hdrm/Views/PopoverView.swift
+++ b/cc-hdrm/Views/PopoverView.swift
@@ -14,7 +14,7 @@ struct PopoverView: View {
     var onSignIn: (() -> Void)?
     var onSignOut: (() -> Void)?
 
-    /// "cc-hdrm 1.5.0" — name and version from the bundle, shown in the top-left corner.
+    /// Application name and version from the bundle, shown in the top-left corner.
     var appNameAndVersion: String {
         let info = Bundle.main.infoDictionary
         let name = info?["CFBundleName"] as? String ?? "cc-hdrm"


### PR DESCRIPTION
Shows the app name and version (from the bundle's CFBundleName and CFBundleShortVersionString) in the top-left corner of the popover, visible in all auth states.

Also answers the question from issue 108 about where the app version is displayed.

- No hardcoded values — the label tracks each release automatically
- Styled caption2 / tertiary so it reads as a label, not content
- Build verified with xcodebuild

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an app name and version header above the authentication and content views, making application details easier to identify.

* **Updates**
  * Updated the displayed app version to 1.6.0 throughout the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->