### PR TITLE
feat: Fable model usage tracking — persistence and analytics series (Story 21.3)

### DIFF
--- a/_bmad-output/implementation-artifacts/epic-21-context.md
+++ b/_bmad-output/implementation-artifacts/epic-21-context.md
@@ -1,52 +1,49 @@
-# Epic 21 Context: Fable Model Usage Tracking (Phase 6)
+# Epic 21 Context: Fable Model Usage Tracking
 
 <!-- Generated from planning artifacts. Regenerate with compile-epic-context if planning docs change. -->
 
 ## Goal
 
-Claude Fable 5 has its own model-scoped weekly cap (50% of the weekly limit on Max plans) that the app cannot see today. A user can hit the Fable wall while the app reports healthy overall headroom (observed live: Fable 63% vs weekly 67% — the two run independently). This epic parses the usage API's new `limits` array, surfaces the Fable window everywhere existing windows appear (popover, history, analytics, notifications, benchmark), and stays completely invisible for accounts without Fable access.
+Claude Fable 5 has its own model-scoped weekly cap (50% of the weekly limit on Max plans) that the app cannot currently see. A user can hit the Fable wall while the app reports healthy overall headroom (observed live: Fable 63% vs weekly 67%). This epic parses the usage API's new `limits` array, surfaces the Fable window everywhere the existing 5h/7d windows appear (popover, history, analytics, notifications, benchmark), and stays completely invisible for accounts without Fable access.
 
 ## Stories
 
-- Story 21.1: Scoped Limits Parsing & Domain Model
-- Story 21.2: Popover Fable Utilization Display
-- Story 21.3: Persistence & Analytics Series
-- Story 21.4: Fable Threshold Notifications
-- Story 21.5: Benchmark Default Model Update
+- Story 21.1: Scoped limits parsing & domain model
+- Story 21.2: Popover Fable utilization display
+- Story 21.3: Persistence & analytics series
+- Story 21.4: Fable threshold notifications
+- Story 21.5: Benchmark default model update
 
 ## Requirements & Constraints
 
-- The `/api/oauth/usage` response now includes a `limits` array (source of truth for model-scoped caps). Entry fields: `kind` (`session`, `weekly_all`, `weekly_scoped`), `group`, `percent` (0–100), `severity`, `resets_at` (ISO 8601 or null), `is_active`, and `scope` — null for unscoped entries; for scoped entries `scope.model.display_name` carries the label (e.g. "Fable") and `scope.model.id` may be null. `scope.surface` exists and may be null.
-- Legacy per-model windows (`seven_day_sonnet`, `seven_day_opus`) now return `null` and are superseded — the `sevenDaySonnet` parsing is dead code to remove.
-- The response also gained a `spend` object and extended `extra_usage` fields (`daily`, `weekly`, `currency`) — explicitly out of scope for this epic; ignore them.
-- Absent `limits` array, or no `weekly_scoped` entries, must decode cleanly to nil: no crash, nothing displayed, no behavior change. Every feature in this epic degrades to "not shown".
-- Benchmark model list gains `claude-fable-5`; the benchmark request path must work end to end with that model ID.
-
-Success criteria:
-
-- Popover shows Fable utilization + reset countdown when the API reports a scoped weekly limit; shows nothing when it doesn't.
-- Fable history appears in analytics after at least one poll cycle post-migration.
-- Notifications fire at 20% and 5% Fable headroom, once per threshold crossing.
-- Benchmark can measure `claude-fable-5` end to end.
-- Zero behavior change for accounts without Fable access.
+- The `/api/oauth/usage` response now includes a `limits` array. Entries carry `kind` (`session`, `weekly_all`, `weekly_scoped`), `group`, `percent` (0-100), `severity`, `resets_at` (ISO 8601 or null), `is_active`, and an optional `scope` object; model-scoped entries carry `scope.model.display_name` (e.g. "Fable") while `scope.model.id` may be null.
+- The `limits` array is the source of truth for model-scoped caps. Legacy `seven_day_sonnet` / `seven_day_opus` fields now return `null`; the `sevenDaySonnet` parsing is dead code and must be removed.
+- Responses without a `limits` array, or without any `weekly_scoped` entry, must decode cleanly to nil — no crash, no display, no behavior change of any kind for accounts without Fable access.
+- The response also gained a `spend` object and extended `extra_usage` fields (`daily`, `weekly`, `currency`) — explicitly out of scope for this epic; leave unparsed.
+- Success criteria: popover shows Fable utilization + reset countdown only when the API reports a scoped weekly limit; Fable history appears in analytics after at least one poll cycle post-migration; notifications fire at 20% and 5% Fable headroom, once per crossing; benchmark can measure `claude-fable-5` end to end.
 
 ## Technical Decisions
 
-- **Generic parsing, no hardcoded model names.** Decode `weekly_scoped` entries into a generic scoped-limit struct and label UI with the API's `scope.model.display_name`. Future model-scoped caps must appear without code changes.
-- **Additive only.** New optional fields in the response model; new nullable SQLite columns (`fable_weekly_util REAL`, `fable_weekly_resets_at INTEGER` on `usage_snapshots`, plus matching rollup aggregates). Schema migration bumps the tracked schema version. No new services, no new patterns.
-- **Copy existing precedents rather than inventing:** window display follows the existing 5h/7d window components; persistence follows the Epic 17 extra-usage column migration precedent (`cc-hdrm/Services/DatabaseManager.swift`, `cc-hdrm/Services/HistoricalDataService.swift`, `cc-hdrm/Models/UsagePoll.swift`); notifications follow the existing 20%/5% headroom model in `cc-hdrm/Services/NotificationService.swift`; benchmark follows Epic 20 (`cc-hdrm/Views/BenchmarkSectionView.swift`, `cc-hdrm/Services/BenchmarkService.swift`).
-- Rollups are lazy (computed on analytics open); the new columns must flow through the existing snapshot → rollup aggregation path.
-- The token-throughput pipeline (Epic 20) is already model-agnostic — Fable tokens flow through the existing log parser keyed by model string. Only the benchmark default model list changes.
+- **Generic parsing, no hardcoded model names.** Decode `weekly_scoped` entries generically and label the UI with the API's `scope.model.display_name`. Future model-scoped caps must appear without code changes.
+- **Additive only.** New optional fields on the response/domain models; new nullable DB columns via an additive schema migration (bump SQLite `user_version`, no destructive changes). Every feature degrades to "not shown" when the scoped limit is absent.
+- **Copy existing precedents, no new patterns or services:**
+  - Window display: existing 5h/7d bar + countdown components (Epics 3/4).
+  - Persistence: Epic 17 extra-usage column precedent — nullable columns on the snapshot table plus rollup aggregates (`cc-hdrm/Services/DatabaseManager.swift`, `cc-hdrm/Services/HistoricalDataService.swift`, `cc-hdrm/Models/UsagePoll.swift`). New columns: `fable_weekly_util REAL`, `fable_weekly_resets_at INTEGER`.
+  - Notifications: existing threshold state machines in `cc-hdrm/Services/NotificationService.swift` — fire once per crossing, re-arm on recovery, independent state machine per window, thresholds read hot from `PreferencesManager` (defaults: 20% headroom warning, 5% critical).
+  - Benchmark: Epic 20 pipeline is model-agnostic; only add `claude-fable-5` to `defaultModels` in `cc-hdrm/Views/BenchmarkSectionView.swift` and verify the `cc-hdrm/Services/BenchmarkService.swift` request path.
+- Parsing entry point: `cc-hdrm/Models/UsageResponse.swift`; scoped-limit data flows through the domain layer to views the same way the existing windows do.
 
 ## UX & Interaction Patterns
 
-- Popover detailed panel: one additional row/gauge for the scoped limit, labeled with the API-provided display name, with reset countdown in both relative and absolute form — matching the existing windows exactly. Hidden entirely when no scoped limit is reported.
-- Analytics window: one additional series toggle for Fable utilization, following the existing series-toggle pattern. No new interaction design anywhere in this epic.
+- Popover: one additional row/gauge in the detailed usage panel, labeled with the API-provided display name, showing utilization plus reset countdown in both relative and absolute form, matching the existing 5h/7d rows. Hidden entirely when no scoped limit is reported.
+- Analytics window: one additional series toggle following the existing 5h/7d toggle pattern (toggleable overlay, legend entry, toggle state persisted per time range).
+- Notifications must be self-contained: percentage, threshold, and reset countdown in the alert itself, consistent with existing threshold notifications.
 - Benchmark UI copy must note that Fable benchmarks consume the Fable cap; the benchmark stays behind the existing opt-in Measure button.
+- No new interaction design anywhere — quiet degradation, no placeholder or empty state when Fable is absent.
 
 ## Cross-Story Dependencies
 
 - 21.1 → 21.2 → 21.3 → 21.4 are sequential; each builds on the parsed domain data from 21.1.
-- 21.5 (benchmark) is independent of 21.1–21.4 and can run at any time.
-- 21.3 depends on the Epic 17 migration precedent already in the codebase; 21.4 dedup state must be independent per window so Fable alerts don't suppress or duplicate existing window alerts.
-- `sprint-status.yaml` is a shared resource — each story branch updates only its own entry.
+- 21.5 is fully independent of 21.1–21.4 and can run at any time.
+- 21.1 and 21.2 are already merged to master (shipped together); remaining work starts at 21.3.
+- Sprint status (`_bmad-output/implementation-artifacts/sprint-status.yaml`) is a shared resource — each story branch updates only its own entry.

--- a/_bmad-output/implementation-artifacts/spec-21-3-fable-persistence-analytics-series.md
+++ b/_bmad-output/implementation-artifacts/spec-21-3-fable-persistence-analytics-series.md
@@ -1,0 +1,188 @@
+---
+title: 'Story 21.3: Fable Persistence & Analytics Series'
+type: 'feature'
+created: '2026-08-13'
+status: 'done'
+review_loop_iteration: 0
+baseline_revision: 'a19b9ea5870216fac792093fddf3fd08073d9cbc'
+followup_review_recommended: true
+context: []
+warnings: [oversized]
+deferred:
+  - summary: >-
+      Multi-statement schema migrations run outside a transaction; a crash
+      mid-block can wedge the database permanently on retry
+    evidence: |-
+      runMigrations() executes each version block's statements without
+      BEGIN/COMMIT and writes user_version once at the end. A crash between
+      ALTERs (e.g. after 2 of the 5 v8 statements) leaves the version
+      unbumped; the next launch re-runs the block, the first duplicate
+      ADD COLUMN throws, ensureSchema fails, and historical features stay
+      disabled forever. Pre-existing pattern affecting every multi-statement
+      migration since v2->v3; surfaced by review of story 21.3, not caused
+      by it.
+    location: >-
+      cc-hdrm/Services/DatabaseManager.swift:141
+    severity: medium
+---
+
+<intent-contract>
+
+## Intent
+
+**Problem:** Model-scoped weekly caps (e.g. Claude Fable 5) are parsed (21.1) and shown live in the popover (21.2), but never persisted — analytics has no Fable history, so a user cannot see how their Fable window evolved.
+
+**Approach:** Additive schema migration (v7→v8) adding nullable Fable columns to `usage_polls` and rollup aggregates to `usage_rollups`; persist the first `weekly_scoped` entry each poll; analytics window gains a Fable series (step-area line + bars) behind a toggle chip that follows the 5h/7d pattern and is hidden entirely when no Fable data exists.
+
+## Boundaries & Constraints
+
+**Always:**
+- The snapshot table is **`usage_polls`** — the epic's `usage_snapshots` name does not exist in this codebase.
+- Poll columns: `fable_weekly_util REAL` (0–100, as reported), `fable_weekly_resets_at INTEGER` (Unix **milliseconds**, via `Date.fromISO8601` → `Int64(t*1000)`, same as existing `*_resets_at`). Rollup columns: `fable_weekly_avg REAL`, `fable_weekly_peak REAL`, `fable_weekly_min REAL` (avg/peak/min triple, mirroring 5h/7d — not the extra-usage MAX/SUM pair). `resets_at` is not rolled up (no 5h/7d precedent).
+- Additive only: new columns appended at the **end** of both CREATE TABLE literals *and* as a new final `if existingVersion < 8` block in `runMigrations()` — fresh and migrated DBs must have identical `PRAGMA table_info` ordering (rows are read positionally).
+- Persist from the raw `UsageResponse` inside `persistPoll` (the persistence Task is off-MainActor; never read `AppState`). Extract the **first** `kind == "weekly_scoped"` entry via a shared helper on `UsageResponse` also adopted by `PollingEngine`'s existing filter, so the two extractions cannot drift.
+- Nil-safe end to end: response without `limits` or without a `weekly_scoped` entry → NULL columns, and every aggregation uses `compactMap` (NULL never becomes 0).
+- Toggle chip labeled from live `appState.scopedLimits.first?.displayName`, fallback `"Model"` (21.2 precedent); chip rendered only when the loaded chart data contains at least one non-nil Fable value. Toggle state session-only per time range (13-4 precedent — no UserDefaults), toggling must not reload data.
+- Fable series color: one new `static let fableColor` (system `.indigo`) beside `sevenDayColor`, re-exported on `BarChartView` — no reuse of extra-usage tokens.
+- Accessibility parity with existing chips/tooltips; `xcodegen generate` after adding files.
+
+**Block If:**
+- Rendering the Fable bars requires changing the existing 5h/7d bar layout *when the Fable series is hidden or absent* — existing two-series output must stay pixel-identical in that case.
+- The migration cannot be expressed as pure `ADD COLUMN` statements.
+
+**Never:**
+- No notifications (21.4), no benchmark changes (21.5), no menu bar or popover changes, no tap-to-analytics wiring.
+- No parsing of `spend` / extended `extra_usage` fields; no backfill (pre-migration rows stay NULL — no source data exists).
+- No persistence of display names; no hardcoded model names in UI labels (DB column names `fable_*` are fixed by the epic).
+- Do not touch `cc-hdrm/cc_hdrm.entitlements`, `Sparkline.swift` constants, or retention/prune/outage logic (all column-agnostic).
+
+## I/O & Edge-Case Matrix
+
+| Scenario | Input / State | Expected Output / Behavior | Error Handling |
+|----------|--------------|---------------------------|----------------|
+| Poll with Fable cap | `limits` has `weekly_scoped` entry, percent 63, resets_at set | Row stores `fable_weekly_util=63.0`, `fable_weekly_resets_at` in ms | No error |
+| Poll without scoped limit | `limits` nil or no `weekly_scoped` entry | Both columns NULL; poll otherwise identical to today | No crash |
+| Scoped entry, nil resets_at | percent set, `resets_at` null | util stored, resets_at NULL | No crash |
+| v7 DB migrates | Existing DB with data, `user_version=7` | v8: new columns exist, old rows intact with NULL fable values, version=8 | Migration failure leaves version unbumped |
+| Fresh install | No DB | v8 schema; column order matches migrated DB | No error |
+| Rollup aggregation | Raw polls with fable utils in a 5min/hourly/daily bucket | avg/peak/min computed; bucket with all-NULL fable → NULL aggregates | No crash |
+| Reset inside bucket | Rollup bucket split by reset event | Reconstructed `UsageRollup` retains fable fields (the `pollsToRollupsWithResets` trap) | No silent drop |
+| Analytics, Fable data present | ≥1 poll/rollup row with non-nil fable util | "Fable" (display-name) chip appears; series renders in step-area + bar modes; tooltip row shown | No error |
+| Analytics, no Fable data | All fable columns NULL in range | No chip, no series, charts identical to today | No crash |
+| Pre-migration boundary | NULLs before migration date, values after | Series line starts partway through window; gap logic pens up (fable has its own filtered array) | No crash |
+| Toggle off | Chip clicked | Series hidden without data reload; state kept per time range for the session | No error |
+
+</intent-contract>
+
+## Code Map
+
+**Persistence:**
+- `cc-hdrm/Services/DatabaseManager.swift` — `currentSchemaVersion=7` at :6 → bump to 8; `runMigrations()` :141 (append `< 8` block after :172-style v-blocks; pattern at :150-157); CREATE literals `createUsagePollsTable` :260-282, `createUsageRollupsTable` :284-313 (append columns at end); `executeSQL` :246 is the ALTER helper. No backfill (contrast :473).
+- `cc-hdrm/Models/UsagePoll.swift` :18-27 — Epic 17 fields are `var … = nil`; add `fableWeeklyUtil: Double?`, `fableWeeklyResetsAt: Int64?` the same way (keeps ~50 existing constructions compiling).
+- `cc-hdrm/Models/UsageRollup.swift` :32-38 — add `fableWeeklyAvg/Peak/Min: Double? = nil` with aggregation doc comments.
+- `cc-hdrm/Models/UsageResponse.swift` — add the shared `weekly_scoped` extraction helper (e.g. computed `weeklyScopedEntries`).
+- `cc-hdrm/Services/PollingEngine.swift` :240-247 — existing `weekly_scoped` filter; refactor onto the shared helper. Persistence dispatch at :296-340 passes the raw response — no change needed there.
+- `cc-hdrm/Services/HistoricalDataService.swift` — `persistPoll` extraction :76-100, INSERT :104-117 + binds :134-188 (add placeholders 11-12, `sqlite3_bind_null` on nil); positional reads: `readPollRow` :422-457 (indices 11-12) and its four SELECT sites :230-237, :290-297, :939-946; rollup tiers `performRawTo5MinRollup` :898-906, `perform5MinToHourlyRollup` :1186-1194, `performHourlyToDailyRollup` :1252-1290 (fable avg/peak/min via `compactMap`, 5h/7d style :890-896); `insertRollup` :1023-1107 (+3 params/SQL/binds); `queryRollupsForRollup` :1318-1404 (SQL + positional 15-17 + `UsageRollup(...)`); `pollToRollup` :1478 (map fable util into avg/peak/min — else last-24h chart shows nothing); **`pollsToRollupsWithResets` :1520-1536 re-constructs `UsageRollup` field-by-field — add fable fields or they're silently dropped in reset buckets**.
+
+**Analytics:**
+- `cc-hdrm/Views/AnalyticsView.swift` — `SeriesVisibility` :25-28 (+`fable: Bool = true`), dict :35, accessors/bindings :38-60, `seriesToggles` :475-495 (+chip after 7d, conditional on data presence), `seriesToggleButton` :497 (reuse as-is); `fetchData` :352-424 and `DataLoadResult` :334-340 need no new queries — fable rides the same rows; derive `hasFableData` from loaded polls/rollups. Label via `appState.scopedLimits.first?.displayName ?? "Model"`.
+- `cc-hdrm/Views/UsageChart.swift` :8-30 — add `fableVisible` param; `anySeriesVisible` :27; thread into both chart views.
+- `cc-hdrm/Views/StepAreaChartView.swift` — `sevenDayColor` :145 (+`fableColor`); filtered arrays :169-172 (+fable points array); `ChartPoint` :293-305 + `makeChartPoints` :316-348 (+fableUtil); gap filter :186 must include fable; **both explicit `ChartPoint(...)` re-constructions :255-267 and :494-506 must carry fable**; `enforceMonotonicWithinSegments` :434-511 (mirror 7d running-max for fable); series namespace `"fable-\(segment)"` (cf. :674/:684); marks in `StaticChartContent`; params threaded through `ChartWithHoverOverlay` :519-534, `StaticChartContent` :626-636, `HoverOverlayContent` :789-798; tooltip row (cf. :928).
+- `cc-hdrm/Views/BarChartView.swift` — re-export color :22; `BarPoint` :33-52 (+fable avg/peak/min); `makeBarPoints` :92-173 (fable arm via `compactMap`, style :137-144); **`barBounds(for:series:)` :353-375 + `bothVisible` :341 currently split the period for exactly 2 series — generalize to N visible series**; render marks (cf. :436-464); params :235-241, :332-338, :579-589; tooltip row (cf. :681).
+
+**Tests (patterns):**
+- `cc-hdrmTests/Services/DatabaseManagerTests.swift` — migration template :295-381; version literals to bump at :54, :62, :205, :292, :380, :606, :769; column-list tests :385-451.
+- `cc-hdrmTests/Services/HistoricalDataServiceTests.swift` — Epic 17 persistence/rollup precedents :1236-1310, :1653-1700; `UsageResponse(...)` built positionally with `limits:` param.
+- `cc-hdrmTests/Views/UsageChartTests.swift` — `makeChart` helper :11-31 (add defaulted `fableVisible`), 17.5 data-test template :1125-1262.
+- `cc-hdrmTests/Views/AnalyticsViewTests.swift` — toggle suite :269-492 to extend for `fable` field.
+- `cc-hdrmTests/Services/PollingEngineTests.swift` :347 — existing `weekly_scoped` test guards the refactored helper.
+
+## Tasks & Acceptance
+
+**Execution:**
+- `cc-hdrm/Models/UsageResponse.swift` — add shared `weeklyScopedEntries` helper — single source for the `weekly_scoped` filter.
+- `cc-hdrm/Services/PollingEngine.swift` — refactor :240-247 onto the helper — prevents drift with persistence.
+- `cc-hdrm/Models/UsagePoll.swift` + `cc-hdrm/Models/UsageRollup.swift` — add optional fable fields with `= nil` defaults — source-compatible model extension.
+- `cc-hdrm/Services/DatabaseManager.swift` — bump schema to 8, add migration block + CREATE-literal columns — additive migration for both upgrade and fresh-install paths.
+- `cc-hdrm/Services/HistoricalDataService.swift` — extend INSERT/binds, all four positional SELECT sites + `readPollRow`, three rollup tiers, `insertRollup`, `queryRollupsForRollup`, `pollToRollup`, `pollsToRollupsWithResets` — full write/read/aggregate path for the new columns.
+- `cc-hdrm/Views/AnalyticsView.swift` — `fable` visibility flag + conditional chip labeled from `scopedLimits` — toggle UX per 13-4 pattern.
+- `cc-hdrm/Views/UsageChart.swift`, `cc-hdrm/Views/StepAreaChartView.swift`, `cc-hdrm/Views/BarChartView.swift` — thread `fableVisible`, add fable series (points array, gap filter, monotonic clamp, marks, generalized bar bounds, tooltip rows, `fableColor`) — renders the series in both chart modes.
+- `cc-hdrmTests/Services/DatabaseManagerTests.swift` — v7→v8 migration test (template :295-381), column-list updates, version-literal bumps — locks the migration.
+- `cc-hdrmTests/Services/HistoricalDataServiceTests.swift` — persist present/nil, round-trip via `getLastPoll`, tier aggregation avg/peak/min, `pollToRollup` passthrough, reset-bucket reconstruction — covers the I/O matrix persistence rows.
+- `cc-hdrmTests/Views/UsageChartTests.swift` + `cc-hdrmTests/Views/AnalyticsViewTests.swift` — fable series rendering/visibility/gap tests; toggle-state tests incl. chip hidden when no data — covers the analytics matrix rows.
+- Run `xcodegen generate` if any new file is added — project regeneration.
+
+**Acceptance Criteria:**
+- Given a poll whose API response reports a `weekly_scoped` limit, when the analytics window opens after that poll persists, then the chart offers a series chip labeled with the API display name and renders the Fable series in both `.day` (step-area) and rollup (bar) modes.
+- Given an account whose polls never report a scoped limit, when analytics opens on any time range, then no Fable chip or series appears and the window is visually unchanged from today.
+- Given a database created at schema v7 with existing history, when the app launches with this change, then `user_version` becomes 8, prior rows survive with NULL fable columns, and new polls populate them.
+- Given the Fable chip is toggled off and the time range is switched away and back, when the session continues, then the off state is remembered per range without any data reload.
+
+## Spec Change Log
+
+## Review Triage Log
+
+### 2026-08-13 — Review pass
+- intent_gap: 0
+- bad_spec: 0
+- patch: 9: (high 0, medium 3, low 6)
+- defer: 1: (high 0, medium 1, low 0)
+- reject: 14: (high 0, medium 0, low 14)
+- addressed_findings:
+  - `[medium]` `[patch]` Fable aggregation in 5min→hourly and hourly→daily rollup tiers had zero test coverage (deleting the arms passed the suite) — added `fableAggregationAcrossHigherRollupTiers` driving 8-day and 31-day-old data through consolidation, asserting avg/peak/min and NULL passthrough at both tiers.
+  - `[medium]` `[patch]` Generalized N-slot `barBounds` math was covered only by a no-assertion render smoke test despite the Block-If pixel-parity requirement — extracted static `slotBounds(index:count:duration:)` and added tests asserting exact equality with the legacy 1- and 2-series formulas plus 3-series non-overlap.
+  - `[medium]` `[patch]` Epic success criterion "Fable history appears in analytics after ≥1 poll cycle" was covered only as disconnected units — added `fableHistoryAppearsAfterOnePollCycle`: real service + temp DB, `persistPoll` → `AnalyticsView.fetchData` → fable util present and `hasFableData` true.
+  - `[low]` `[patch]` Dead `guard let percent` in PollingEngine compactMap (helper already filters nil percent) — simplified via `entry.percent.map`.
+  - `[low]` `[patch]` Whitespace-only hunk in `createIndex` SQL literal — restored original trailing space; unrelated hunk removed from diff.
+  - `[low]` `[patch]` Circular test assertion (expected resets-at computed with the same `Date.fromISO8601` as production) — hard-coded epoch-ms constants for the fixed ISO fixtures.
+  - `[low]` `[patch]` Empty-string `displayName` rendered a blank chip/tooltip label — `fableLabel(from:)` now falls back for nil/empty/blank, reusing 21.2's `ScopedLimitGaugeSection.fallbackLabel`; test covers all cases.
+  - `[low]` `[patch]` Fable clause in `findGapRanges` was unpinned (reverting it failed no test) — added `fableOnlyPollsDriveGapDetection` with fable-only polls asserting no-gap and one-gap cases.
+  - `[low]` `[patch]` `sprint-status.yaml` not updated for this story — own entry set to done at finalization per shared-resource convention.
+
+Deferred (pre-existing, not this story): multi-statement migrations run outside a transaction — a crash mid-block wedges the DB permanently on retry (duplicate ADD COLUMN); affects every migration since v2→v3.
+
+Rejected findings (noise, dropped): `hasFableData` recompute cost (body does not re-evaluate on hover; O(n) contains a few times per poll); no persisted model identity / historical-label provenance (intent decrees exactly two singular `fable_*` columns; future scoped model needs its own schema story — recorded in Design Notes); toggle-reload test for fable (mechanism shared with 5h/7d, already pinned by the 13-4 test); `weekly_scoped` entry with resetsAt but nil percent dropped (21.1's pre-existing semantics, unchanged by the helper); `createV7Schema` hand-duplication (matches the established migration-test template; drift is caught by the fresh-vs-migrated column-order parity test); `fable_weekly_resets_at` has no consumer/rollup (intent-decreed column; matches 5h/7d precedent of never rolling up resets_at, stated in spec); unweighted avg-of-avgs + helper consolidation (mirrors existing 5h/7d behavior by design; no new abstraction warranted); `?? 0` on pre-filtered fablePoints (exact parity with existing 7d pattern); percent clamping for negative/NaN/>100 (spec directs as-reported storage; NaN unreachable — JSONDecoder rejects non-finite; matches 5h/7d unclamped storage); weekly reset below 10-point drop threshold clamped away (spec-directed parity with the shared heuristic); toggle chip binding not exercised at UI surface (SwiftUI limitation; same dictionary-shape testing as the established 13-4 suite); Reading-B aggregate shape (avg/peak/min chosen and justified in Design Notes; Epic 17 reference governs migration mechanics); monotonic clamp and N-slot generalization as un-asked-for extras (both required for correct rendering parity of a third utilization series).
+
+## Design Notes
+
+- **Why avg/peak/min, not MAX/SUM:** Fable weekly util is the same shape as 5h/7d utilization; the extra-usage MAX/SUM pair exists for monotonic credit counters. Copy the util precedent.
+- **Why first `weekly_scoped` entry:** columns are singular by epic decree; the API currently reports one scoped cap, and API order is already the display order (21.2). A future second scoped model needs its own schema story.
+- **Why `.indigo`:** 7d uses plain `Color.blue` (no asset); a new asset for one hue is overhead, and both extra-usage purples carry spend-tier semantics.
+
+## Verification
+
+**Commands:**
+- `xcodegen generate` — expected: succeeds (only needed if new files are added)
+- `xcodebuild -project cc-hdrm.xcodeproj -scheme cc-hdrm -destination 'platform=macOS' CODE_SIGN_IDENTITY="-" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS= build` — expected: BUILD SUCCEEDED
+- `xcodebuild -project cc-hdrm.xcodeproj -scheme cc-hdrm -destination 'platform=macOS' CODE_SIGN_IDENTITY="-" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS= test` — expected: all tests pass (known flake: `TPPChartDataServiceTests/dailyAverage()` within 4h of local midnight — pre-existing, unrelated)
+
+## Auto Run Result
+
+**Status:** done
+
+**Summary:** Fable model-scoped weekly cap data is now persisted and charted. Schema v7→v8 adds `fable_weekly_util`/`fable_weekly_resets_at` to `usage_polls` and `fable_weekly_avg/peak/min` to `usage_rollups` (pure additive `ADD COLUMN`, identical column order for fresh and migrated databases). Every poll stores the first `weekly_scoped` entry from the API response via a shared `weeklyScopedEntries` helper also used by the live popover path. The analytics window gains a Fable series — indigo line in the 24h step-area chart, indigo bars in rollup ranges — behind a toggle chip labeled with the API display name ("Model" fallback), shown only when loaded data contains Fable values. Accounts without Fable access see zero change anywhere.
+
+**Files changed:**
+- `cc-hdrm/Models/UsageResponse.swift` — shared `weeklyScopedEntries` filter helper.
+- `cc-hdrm/Models/UsagePoll.swift` / `cc-hdrm/Models/UsageRollup.swift` — optional fable fields with `= nil` defaults.
+- `cc-hdrm/Services/DatabaseManager.swift` — schema version 8, v7→v8 migration block, CREATE-literal columns.
+- `cc-hdrm/Services/HistoricalDataService.swift` — INSERT/binds, four positional SELECT sites + `readPollRow`, three rollup tiers, `insertRollup`, `queryRollupsForRollup`, `pollToRollup`, reset-bucket reconstruction.
+- `cc-hdrm/Services/PollingEngine.swift` — refactored onto the shared helper.
+- `cc-hdrm/Views/AnalyticsView.swift` — `fable` visibility flag per time range, conditional chip, `hasFableData` / `fableLabel(from:)` statics.
+- `cc-hdrm/Views/UsageChart.swift` / `StepAreaChartView.swift` / `BarChartView.swift` — `fableVisible`/`fableLabel` threading, fable points array + gap filter + independent monotonic clamp, `fableColor` (indigo), N-series `slotBounds` generalization, hover/tooltip rows.
+- Tests: `DatabaseManagerTests` (v7→v8 migration, column order parity, version bumps), `HistoricalDataServiceTests` (persist/round-trip/tier aggregation incl. hourly+daily), `UsageChartTests` (chart points, gaps, monotonic, slot bounds, bar aggregation), `AnalyticsViewTests` (toggles, chip gating, label fallback, poll-to-chart integration), `OutageTrackingTests` (version literal bumps).
+
+**Review findings:** 9 patched (3 medium, 6 low — see Review Triage Log), 1 deferred (pre-existing non-transactional migration risk), 14 rejected as noise. No intent gaps, no spec repairs.
+
+**Follow-up review recommendation:** true — patched counts: high 0, medium 3, low 6; score = 3×3 + 1×6 = 15 (threshold 5).
+
+**Verification:**
+- `xcodebuild ... build` — BUILD SUCCEEDED (post-implementation and post-patch).
+- `xcodebuild ... test` — TEST SUCCEEDED: 1520 tests in 129 suites, 0 failures (1514 pre-patch; 6 tests added by review patches).
+- Matrix test audit: every I/O matrix row covered by a test that ran and passed.
+- No new files added — `xcodegen generate` not required.
+
+**Residual risks:**
+- Migration blocks are non-transactional (deferred finding): a crash mid-v8-block would wedge historical features on retry — same exposure as every prior migration.
+- Historical Fable data viewed with no live scoped limit is labeled with the generic "Model" fallback, since display names are deliberately not persisted.
+- `fable_weekly_resets_at` currently has no consumer and is not rolled up; reset history ages out with raw-poll retention (7 days). Story 21.4 uses live data, so this matches the 5h/7d precedent.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -193,7 +193,7 @@ development_status:
   epic-21: in-progress  # Fable Model Usage Tracking (Phase 6) — Sprint change proposal 2026-08-12
   21-1-scoped-limits-parsing-domain-model: done  # bmad-build-auto 2026-08-12
   21-2-popover-fable-utilization-display: done  # bmad-build-auto 2026-08-13
-  21-3-fable-persistence-analytics-series: backlog
+  21-3-fable-persistence-analytics-series: done  # bmad-build-auto 2026-08-13
   21-4-fable-threshold-notifications: backlog
   21-5-benchmark-default-model-update: backlog
 

--- a/cc-hdrm/Models/UsagePoll.swift
+++ b/cc-hdrm/Models/UsagePoll.swift
@@ -25,4 +25,8 @@ struct UsagePoll: Sendable, Equatable {
     /// Extra usage delta: credits consumed between this poll and the previous poll.
     /// Computed as max(0, current.usedCredits - previous.usedCredits). Nil for first poll or no data.
     var extraUsageDelta: Double? = nil
+    /// Model-scoped (Fable) weekly utilization percentage (0-100), nil if not reported
+    var fableWeeklyUtil: Double? = nil
+    /// Model-scoped (Fable) weekly reset time as Unix milliseconds, nil if not reported
+    var fableWeeklyResetsAt: Int64? = nil
 }

--- a/cc-hdrm/Models/UsageResponse.swift
+++ b/cc-hdrm/Models/UsageResponse.swift
@@ -14,6 +14,13 @@ struct UsageResponse: Codable, Sendable, Equatable {
         case limits
         case extraUsage = "extra_usage"
     }
+
+    /// Model-scoped weekly cap entries (`kind == "weekly_scoped"`) that report a percent,
+    /// in API order. Shared by live display (PollingEngine) and persistence so the two
+    /// extractions cannot drift.
+    var weeklyScopedEntries: [LimitEntry] {
+        (limits ?? []).filter { $0.kind == "weekly_scoped" && $0.percent != nil }
+    }
 }
 
 /// Usage data for a single time window (e.g., 5-hour or 7-day).

--- a/cc-hdrm/Models/UsageRollup.swift
+++ b/cc-hdrm/Models/UsageRollup.swift
@@ -36,6 +36,15 @@ struct UsageRollup: Sendable, Equatable {
     /// Extra usage delta: SUM of credits consumed across polls/rollups in this period.
     /// Persisted in rollup DB schema since v5.
     var extraUsageDelta: Double? = nil
+    /// Average model-scoped (Fable) weekly utilization for the period (0-100).
+    /// Persisted in rollup DB schema since v8.
+    var fableWeeklyAvg: Double? = nil
+    /// Peak (max) model-scoped (Fable) weekly utilization for the period.
+    /// Persisted in rollup DB schema since v8.
+    var fableWeeklyPeak: Double? = nil
+    /// Minimum model-scoped (Fable) weekly utilization for the period.
+    /// Persisted in rollup DB schema since v8.
+    var fableWeeklyMin: Double? = nil
 
     /// Resolution tier for aggregated usage data.
     enum Resolution: String, Codable, CaseIterable, Sendable {

--- a/cc-hdrm/Services/DatabaseManager.swift
+++ b/cc-hdrm/Services/DatabaseManager.swift
@@ -3,7 +3,7 @@ import os
 import SQLite3
 
 /// Current database schema version. Increment when schema changes require migration.
-private let currentSchemaVersion: Int = 7
+private let currentSchemaVersion: Int = 8
 
 /// SQLITE_TRANSIENT tells SQLite to make its own copy of the string data.
 /// Required when binding strings from Swift's withCString which uses temporary buffers.
@@ -183,6 +183,16 @@ final class DatabaseManager: DatabaseManagerProtocol, @unchecked Sendable {
             Self.logger.info("Migration v6->v7: created tpp_measurements table")
         }
 
+        if existingVersion < 8 {
+            let connection = try getConnection()
+            try executeSQL("ALTER TABLE usage_polls ADD COLUMN fable_weekly_util REAL", on: connection)
+            try executeSQL("ALTER TABLE usage_polls ADD COLUMN fable_weekly_resets_at INTEGER", on: connection)
+            try executeSQL("ALTER TABLE usage_rollups ADD COLUMN fable_weekly_avg REAL", on: connection)
+            try executeSQL("ALTER TABLE usage_rollups ADD COLUMN fable_weekly_peak REAL", on: connection)
+            try executeSQL("ALTER TABLE usage_rollups ADD COLUMN fable_weekly_min REAL", on: connection)
+            Self.logger.info("Migration v7->v8: added fable weekly columns to usage_polls and usage_rollups")
+        }
+
         Self.logger.info("Migrations complete: \(existingVersion) -> \(currentSchemaVersion)")
         try setSchemaVersion(currentSchemaVersion)
     }
@@ -270,7 +280,9 @@ final class DatabaseManager: DatabaseManagerProtocol, @unchecked Sendable {
                 extra_usage_monthly_limit REAL,
                 extra_usage_used_credits REAL,
                 extra_usage_utilization REAL,
-                extra_usage_delta REAL
+                extra_usage_delta REAL,
+                fable_weekly_util REAL,
+                fable_weekly_resets_at INTEGER
             )
             """
         try executeSQL(createTable, on: connection)
@@ -298,7 +310,10 @@ final class DatabaseManager: DatabaseManagerProtocol, @unchecked Sendable {
                 waste_credits REAL,
                 extra_usage_used_credits REAL,
                 extra_usage_utilization REAL,
-                extra_usage_delta REAL
+                extra_usage_delta REAL,
+                fable_weekly_avg REAL,
+                fable_weekly_peak REAL,
+                fable_weekly_min REAL
             )
             """
         try executeSQL(createTable, on: connection)

--- a/cc-hdrm/Services/HistoricalDataService.swift
+++ b/cc-hdrm/Services/HistoricalDataService.swift
@@ -100,6 +100,13 @@ final class HistoricalDataService: HistoricalDataServiceProtocol, @unchecked Sen
             extraUsageDelta = nil
         }
 
+        // Model-scoped weekly cap: first weekly_scoped entry (shared helper with PollingEngine)
+        let fableEntry = response.weeklyScopedEntries.first
+        let fableWeeklyUtil = fableEntry?.percent
+        let fableWeeklyResetsAt = fableEntry?.resetsAt
+            .flatMap { Date.fromISO8601($0) }
+            .map { Int64($0.timeIntervalSince1970 * 1000) }
+
         // Prepare INSERT statement
         let sql = """
             INSERT INTO usage_polls (
@@ -112,8 +119,10 @@ final class HistoricalDataService: HistoricalDataServiceProtocol, @unchecked Sen
                 extra_usage_monthly_limit,
                 extra_usage_used_credits,
                 extra_usage_utilization,
-                extra_usage_delta
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                extra_usage_delta,
+                fable_weekly_util,
+                fable_weekly_resets_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """
 
         var statement: OpaquePointer?
@@ -187,6 +196,18 @@ final class HistoricalDataService: HistoricalDataServiceProtocol, @unchecked Sen
             sqlite3_bind_null(statement, 10)
         }
 
+        if let util = fableWeeklyUtil {
+            sqlite3_bind_double(statement, 11, util)
+        } else {
+            sqlite3_bind_null(statement, 11)
+        }
+
+        if let resetsAt = fableWeeklyResetsAt {
+            sqlite3_bind_int64(statement, 12, resetsAt)
+        } else {
+            sqlite3_bind_null(statement, 12)
+        }
+
         // Execute
         let stepResult = sqlite3_step(statement)
         guard stepResult == SQLITE_DONE else {
@@ -230,7 +251,7 @@ final class HistoricalDataService: HistoricalDataServiceProtocol, @unchecked Sen
         let sql = """
             SELECT id, timestamp, five_hour_util, five_hour_resets_at, seven_day_util, seven_day_resets_at,
                    extra_usage_enabled, extra_usage_monthly_limit, extra_usage_used_credits, extra_usage_utilization,
-                   extra_usage_delta
+                   extra_usage_delta, fable_weekly_util, fable_weekly_resets_at
             FROM usage_polls
             WHERE timestamp >= ?
             ORDER BY timestamp ASC
@@ -290,7 +311,7 @@ final class HistoricalDataService: HistoricalDataServiceProtocol, @unchecked Sen
         let sql = """
             SELECT id, timestamp, five_hour_util, five_hour_resets_at, seven_day_util, seven_day_resets_at,
                    extra_usage_enabled, extra_usage_monthly_limit, extra_usage_used_credits, extra_usage_utilization,
-                   extra_usage_delta
+                   extra_usage_delta, fable_weekly_util, fable_weekly_resets_at
             FROM usage_polls
             ORDER BY timestamp DESC
             LIMIT 1
@@ -418,7 +439,7 @@ final class HistoricalDataService: HistoricalDataServiceProtocol, @unchecked Sen
     /// Expects columns: id(0), timestamp(1), five_hour_util(2), five_hour_resets_at(3),
     /// seven_day_util(4), seven_day_resets_at(5), extra_usage_enabled(6),
     /// extra_usage_monthly_limit(7), extra_usage_used_credits(8), extra_usage_utilization(9),
-    /// extra_usage_delta(10).
+    /// extra_usage_delta(10), fable_weekly_util(11), fable_weekly_resets_at(12).
     private static func readPollRow(_ statement: OpaquePointer) -> UsagePoll {
         let id = sqlite3_column_int64(statement, 0)
         let timestamp = sqlite3_column_int64(statement, 1)
@@ -440,6 +461,10 @@ final class HistoricalDataService: HistoricalDataServiceProtocol, @unchecked Sen
             ? nil : sqlite3_column_double(statement, 9)
         let extraUsageDelta: Double? = sqlite3_column_type(statement, 10) == SQLITE_NULL
             ? nil : sqlite3_column_double(statement, 10)
+        let fableWeeklyUtil: Double? = sqlite3_column_type(statement, 11) == SQLITE_NULL
+            ? nil : sqlite3_column_double(statement, 11)
+        let fableWeeklyResetsAt: Int64? = sqlite3_column_type(statement, 12) == SQLITE_NULL
+            ? nil : sqlite3_column_int64(statement, 12)
 
         return UsagePoll(
             id: id,
@@ -452,7 +477,9 @@ final class HistoricalDataService: HistoricalDataServiceProtocol, @unchecked Sen
             extraUsageMonthlyLimit: extraUsageMonthlyLimit,
             extraUsageUsedCredits: extraUsageUsedCredits,
             extraUsageUtilization: extraUsageUtilization,
-            extraUsageDelta: extraUsageDelta
+            extraUsageDelta: extraUsageDelta,
+            fableWeeklyUtil: fableWeeklyUtil,
+            fableWeeklyResetsAt: fableWeeklyResetsAt
         )
     }
 
@@ -905,6 +932,12 @@ final class HistoricalDataService: HistoricalDataServiceProtocol, @unchecked Sen
             let deltaValues = bucketPolls.compactMap { $0.extraUsageDelta }
             let extraUsageDelta = deltaValues.isEmpty ? nil : deltaValues.reduce(0, +)
 
+            // Fable weekly: avg/peak/min, mirroring 5h/7d utilization
+            let fableValues = bucketPolls.compactMap { $0.fableWeeklyUtil }
+            let fableWeeklyAvg = fableValues.isEmpty ? nil : fableValues.reduce(0, +) / Double(fableValues.count)
+            let fableWeeklyPeak = fableValues.max()
+            let fableWeeklyMin = fableValues.min()
+
             // Count reset events in this bucket
             let resetCount = try countResetEvents(from: bucketStart, to: bucketEnd, connection: connection)
 
@@ -924,6 +957,9 @@ final class HistoricalDataService: HistoricalDataServiceProtocol, @unchecked Sen
                 extraUsageUsedCredits: extraUsageUsedCredits,
                 extraUsageUtilization: extraUsageUtilization,
                 extraUsageDelta: extraUsageDelta,
+                fableWeeklyAvg: fableWeeklyAvg,
+                fableWeeklyPeak: fableWeeklyPeak,
+                fableWeeklyMin: fableWeeklyMin,
                 connection: connection
             )
         }
@@ -939,7 +975,7 @@ final class HistoricalDataService: HistoricalDataServiceProtocol, @unchecked Sen
         let sql = """
             SELECT id, timestamp, five_hour_util, five_hour_resets_at, seven_day_util, seven_day_resets_at,
                    extra_usage_enabled, extra_usage_monthly_limit, extra_usage_used_credits, extra_usage_utilization,
-                   extra_usage_delta
+                   extra_usage_delta, fable_weekly_util, fable_weekly_resets_at
             FROM usage_polls
             WHERE timestamp >= ? AND timestamp < ?
             ORDER BY timestamp ASC
@@ -1035,6 +1071,9 @@ final class HistoricalDataService: HistoricalDataServiceProtocol, @unchecked Sen
         extraUsageUsedCredits: Double? = nil,
         extraUsageUtilization: Double? = nil,
         extraUsageDelta: Double? = nil,
+        fableWeeklyAvg: Double? = nil,
+        fableWeeklyPeak: Double? = nil,
+        fableWeeklyMin: Double? = nil,
         connection: OpaquePointer
     ) throws {
         let sql = """
@@ -1044,8 +1083,9 @@ final class HistoricalDataService: HistoricalDataServiceProtocol, @unchecked Sen
                 seven_day_avg, seven_day_peak, seven_day_min,
                 reset_count, waste_credits,
                 extra_usage_used_credits, extra_usage_utilization,
-                extra_usage_delta
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                extra_usage_delta,
+                fable_weekly_avg, fable_weekly_peak, fable_weekly_min
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """
 
         var statement: OpaquePointer?
@@ -1098,6 +1138,15 @@ final class HistoricalDataService: HistoricalDataServiceProtocol, @unchecked Sen
 
         if let delta = extraUsageDelta { sqlite3_bind_double(statement, 14, delta) }
         else { sqlite3_bind_null(statement, 14) }
+
+        if let avg = fableWeeklyAvg { sqlite3_bind_double(statement, 15, avg) }
+        else { sqlite3_bind_null(statement, 15) }
+
+        if let peak = fableWeeklyPeak { sqlite3_bind_double(statement, 16, peak) }
+        else { sqlite3_bind_null(statement, 16) }
+
+        if let min = fableWeeklyMin { sqlite3_bind_double(statement, 17, min) }
+        else { sqlite3_bind_null(statement, 17) }
 
         let stepResult = sqlite3_step(statement)
         guard stepResult == SQLITE_DONE else {
@@ -1193,6 +1242,14 @@ final class HistoricalDataService: HistoricalDataServiceProtocol, @unchecked Sen
             let deltaValues = bucketRollups.compactMap { $0.extraUsageDelta }
             let extraUsageDelta = deltaValues.isEmpty ? nil : deltaValues.reduce(0, +)
 
+            // Fable weekly: avg of avgs, max of peaks, min of mins
+            let fableAvgs = bucketRollups.compactMap { $0.fableWeeklyAvg }
+            let fablePeaks = bucketRollups.compactMap { $0.fableWeeklyPeak }
+            let fableMins = bucketRollups.compactMap { $0.fableWeeklyMin }
+            let fableWeeklyAvg = fableAvgs.isEmpty ? nil : fableAvgs.reduce(0, +) / Double(fableAvgs.count)
+            let fableWeeklyPeak = fablePeaks.max()
+            let fableWeeklyMin = fableMins.min()
+
             try insertRollup(
                 periodStart: bucketStart,
                 periodEnd: bucketEnd,
@@ -1208,6 +1265,9 @@ final class HistoricalDataService: HistoricalDataServiceProtocol, @unchecked Sen
                 extraUsageUsedCredits: extraUsageUsedCredits,
                 extraUsageUtilization: extraUsageUtilization,
                 extraUsageDelta: extraUsageDelta,
+                fableWeeklyAvg: fableWeeklyAvg,
+                fableWeeklyPeak: fableWeeklyPeak,
+                fableWeeklyMin: fableWeeklyMin,
                 connection: connection
             )
         }
@@ -1289,6 +1349,14 @@ final class HistoricalDataService: HistoricalDataServiceProtocol, @unchecked Sen
             let deltaValues = bucketRollups.compactMap { $0.extraUsageDelta }
             let extraUsageDelta = deltaValues.isEmpty ? nil : deltaValues.reduce(0, +)
 
+            // Fable weekly: avg of avgs, max of peaks, min of mins
+            let fableAvgs = bucketRollups.compactMap { $0.fableWeeklyAvg }
+            let fablePeaks = bucketRollups.compactMap { $0.fableWeeklyPeak }
+            let fableMins = bucketRollups.compactMap { $0.fableWeeklyMin }
+            let fableWeeklyAvg = fableAvgs.isEmpty ? nil : fableAvgs.reduce(0, +) / Double(fableAvgs.count)
+            let fableWeeklyPeak = fablePeaks.max()
+            let fableWeeklyMin = fableMins.min()
+
             try insertRollup(
                 periodStart: bucketStart,
                 periodEnd: bucketEnd,
@@ -1304,6 +1372,9 @@ final class HistoricalDataService: HistoricalDataServiceProtocol, @unchecked Sen
                 extraUsageUsedCredits: extraUsageUsedCredits,
                 extraUsageUtilization: extraUsageUtilization,
                 extraUsageDelta: extraUsageDelta,
+                fableWeeklyAvg: fableWeeklyAvg,
+                fableWeeklyPeak: fableWeeklyPeak,
+                fableWeeklyMin: fableWeeklyMin,
                 connection: connection
             )
         }
@@ -1327,7 +1398,8 @@ final class HistoricalDataService: HistoricalDataServiceProtocol, @unchecked Sen
                    seven_day_avg, seven_day_peak, seven_day_min,
                    reset_count, waste_credits,
                    extra_usage_used_credits, extra_usage_utilization,
-                   extra_usage_delta
+                   extra_usage_delta,
+                   fable_weekly_avg, fable_weekly_peak, fable_weekly_min
             FROM usage_rollups
             WHERE resolution = ? AND period_start >= ? AND period_start < ?
             ORDER BY period_start ASC
@@ -1380,6 +1452,12 @@ final class HistoricalDataService: HistoricalDataServiceProtocol, @unchecked Sen
                 ? nil : sqlite3_column_double(statement, 13)
             let extraUsageDelta: Double? = sqlite3_column_type(statement, 14) == SQLITE_NULL
                 ? nil : sqlite3_column_double(statement, 14)
+            let fableWeeklyAvg: Double? = sqlite3_column_type(statement, 15) == SQLITE_NULL
+                ? nil : sqlite3_column_double(statement, 15)
+            let fableWeeklyPeak: Double? = sqlite3_column_type(statement, 16) == SQLITE_NULL
+                ? nil : sqlite3_column_double(statement, 16)
+            let fableWeeklyMin: Double? = sqlite3_column_type(statement, 17) == SQLITE_NULL
+                ? nil : sqlite3_column_double(statement, 17)
 
             rollups.append(UsageRollup(
                 id: id,
@@ -1396,7 +1474,10 @@ final class HistoricalDataService: HistoricalDataServiceProtocol, @unchecked Sen
                 unusedCredits: unusedCredits,
                 extraUsageUsedCredits: extraUsageUsedCredits,
                 extraUsageUtilization: extraUsageUtilization,
-                extraUsageDelta: extraUsageDelta
+                extraUsageDelta: extraUsageDelta,
+                fableWeeklyAvg: fableWeeklyAvg,
+                fableWeeklyPeak: fableWeeklyPeak,
+                fableWeeklyMin: fableWeeklyMin
             ))
         }
 
@@ -1491,7 +1572,10 @@ final class HistoricalDataService: HistoricalDataServiceProtocol, @unchecked Sen
             unusedCredits: nil,
             extraUsageUsedCredits: poll.extraUsageUsedCredits,
             extraUsageUtilization: poll.extraUsageUtilization,
-            extraUsageDelta: poll.extraUsageDelta
+            extraUsageDelta: poll.extraUsageDelta,
+            fableWeeklyAvg: poll.fableWeeklyUtil,
+            fableWeeklyPeak: poll.fableWeeklyUtil,
+            fableWeeklyMin: poll.fableWeeklyUtil
         )
     }
 
@@ -1532,7 +1616,10 @@ final class HistoricalDataService: HistoricalDataServiceProtocol, @unchecked Sen
                     unusedCredits: rollup.unusedCredits,
                     extraUsageUsedCredits: rollup.extraUsageUsedCredits,
                     extraUsageUtilization: rollup.extraUsageUtilization,
-                    extraUsageDelta: rollup.extraUsageDelta
+                    extraUsageDelta: rollup.extraUsageDelta,
+                    fableWeeklyAvg: rollup.fableWeeklyAvg,
+                    fableWeeklyPeak: rollup.fableWeeklyPeak,
+                    fableWeeklyMin: rollup.fableWeeklyMin
                 )
             }
             return rollup

--- a/cc-hdrm/Services/PollingEngine.swift
+++ b/cc-hdrm/Services/PollingEngine.swift
@@ -237,13 +237,14 @@ final class PollingEngine: PollingEngineProtocol {
                 )
             }
 
-            let scopedLimitStates: [ScopedLimitState] = (response.limits ?? []).compactMap { entry in
-                guard entry.kind == "weekly_scoped", let percent = entry.percent else { return nil }
-                return ScopedLimitState(
-                    displayName: entry.scope?.model?.displayName,
-                    utilization: percent,
-                    resetsAt: entry.resetsAt.flatMap { Date.fromISO8601($0) }
-                )
+            let scopedLimitStates: [ScopedLimitState] = response.weeklyScopedEntries.compactMap { entry in
+                entry.percent.map { percent in
+                    ScopedLimitState(
+                        displayName: entry.scope?.model?.displayName,
+                        utilization: percent,
+                        resetsAt: entry.resetsAt.flatMap { Date.fromISO8601($0) }
+                    )
+                }
             }
 
             // Resolve credit limits from tier string each cycle (tier could change on subscription upgrade)

--- a/cc-hdrm/Views/AnalyticsView.swift
+++ b/cc-hdrm/Views/AnalyticsView.swift
@@ -25,6 +25,7 @@ struct AnalyticsView: View {
     internal struct SeriesVisibility: Equatable {
         var fiveHour: Bool = true
         var sevenDay: Bool = true
+        var fable: Bool = true
     }
 
     // Default to .week — shows recent trends without overwhelming detail.
@@ -44,6 +45,11 @@ struct AnalyticsView: View {
         seriesVisibility[selectedTimeRange]?.sevenDay ?? true
     }
 
+    /// Whether the model-scoped (Fable) series is toggled on for the currently selected time range.
+    private var fableVisible: Bool {
+        seriesVisibility[selectedTimeRange]?.fable ?? true
+    }
+
     /// Binding that reads/writes 5-hour visibility for the current time range.
     private var fiveHourBinding: Binding<Bool> {
         Binding(
@@ -58,6 +64,38 @@ struct AnalyticsView: View {
             get: { seriesVisibility[selectedTimeRange]?.sevenDay ?? true },
             set: { seriesVisibility[selectedTimeRange, default: SeriesVisibility()].sevenDay = $0 }
         )
+    }
+
+    /// Binding that reads/writes Fable series visibility for the current time range.
+    private var fableBinding: Binding<Bool> {
+        Binding(
+            get: { seriesVisibility[selectedTimeRange]?.fable ?? true },
+            set: { seriesVisibility[selectedTimeRange, default: SeriesVisibility()].fable = $0 }
+        )
+    }
+
+    /// Whether the loaded chart data contains at least one non-nil Fable value.
+    /// Gates both the toggle chip and the rendered series.
+    private var hasFableData: Bool {
+        Self.hasFableData(polls: chartData, rollups: rollupData)
+    }
+
+    /// Static for testability (same pattern as `fetchData`).
+    static func hasFableData(polls: [UsagePoll], rollups: [UsageRollup]) -> Bool {
+        polls.contains { $0.fableWeeklyUtil != nil }
+            || rollups.contains { $0.fableWeeklyAvg != nil || $0.fableWeeklyPeak != nil || $0.fableWeeklyMin != nil }
+    }
+
+    /// Label for the Fable series chip and tooltip rows — live API display name,
+    /// generic fallback when nil or blank (21.2 `ScopedLimitGaugeSection` precedent).
+    private var fableLabel: String {
+        Self.fableLabel(from: appState.scopedLimits.first?.displayName)
+    }
+
+    /// Static for testability (same pattern as `hasFableData`).
+    static func fableLabel(from displayName: String?) -> String {
+        let trimmed = displayName?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? ScopedLimitGaugeSection.fallbackLabel : trimmed
     }
 
     @State private var chartData: [UsagePoll] = []
@@ -91,6 +129,8 @@ struct AnalyticsView: View {
                 timeRange: selectedTimeRange,
                 fiveHourVisible: fiveHourVisible,
                 sevenDayVisible: sevenDayVisible,
+                fableVisible: fableVisible && hasFableData,
+                fableLabel: fableLabel,
                 isLoading: isLoading,
                 hasAnyHistoricalData: hasAnyHistoricalData,
                 outagePeriods: outagePeriods
@@ -491,6 +531,19 @@ struct AnalyticsView: View {
                 isActive: sevenDayBinding,
                 accessibilityPrefix: "7-day series"
             )
+
+            if hasFableData {
+                Text("|")
+                    .font(.caption)
+                    .foregroundStyle(.quaternary)
+
+                seriesToggleButton(
+                    label: fableLabel,
+                    color: StepAreaChartView.fableColor,
+                    isActive: fableBinding,
+                    accessibilityPrefix: "\(fableLabel) series"
+                )
+            }
         }
     }
 

--- a/cc-hdrm/Views/BarChartView.swift
+++ b/cc-hdrm/Views/BarChartView.swift
@@ -8,6 +8,9 @@ import SwiftUI
 struct BarChartView: View {
     let fiveHourVisible: Bool
     let sevenDayVisible: Bool
+    let fableVisible: Bool
+    /// Display label for the model-scoped (Fable) series — from the live API display name.
+    let fableLabel: String
     let timeRange: TimeRange
 
     /// Pre-computed bar points — built in init, never recomputed on hover.
@@ -20,6 +23,8 @@ struct BarChartView: View {
 
     /// 7-day series color — reuses StepAreaChartView constant.
     static let sevenDayColor = StepAreaChartView.sevenDayColor
+    /// Model-scoped (Fable) series color — reuses StepAreaChartView constant.
+    static let fableColor = StepAreaChartView.fableColor
 
     // MARK: - Data Types
 
@@ -49,14 +54,30 @@ struct BarChartView: View {
         var extraUsageUtilization: Double? = nil
         /// Extra usage delta: SUM of credits consumed in this period (nil if unavailable)
         var extraUsageDelta: Double? = nil
+        /// Fable weekly peak utilization for this period (nil if unavailable)
+        var fablePeak: Double? = nil
+        /// Fable weekly average utilization for this period (nil if unavailable)
+        var fableAvg: Double? = nil
+        /// Fable weekly minimum utilization for this period (nil if unavailable)
+        var fableMin: Double? = nil
     }
 
     // MARK: - Init
 
-    init(rollups: [UsageRollup], timeRange: TimeRange, fiveHourVisible: Bool, sevenDayVisible: Bool, outagePeriods: [OutagePeriod] = []) {
+    init(
+        rollups: [UsageRollup],
+        timeRange: TimeRange,
+        fiveHourVisible: Bool,
+        sevenDayVisible: Bool,
+        fableVisible: Bool = false,
+        fableLabel: String = "Model",
+        outagePeriods: [OutagePeriod] = []
+    ) {
         self.timeRange = timeRange
         self.fiveHourVisible = fiveHourVisible
         self.sevenDayVisible = sevenDayVisible
+        self.fableVisible = fableVisible
+        self.fableLabel = fableLabel
         let points = Self.makeBarPoints(from: rollups, timeRange: timeRange)
         self.barPoints = points
         self.gapRanges = Self.findGapRanges(in: points, timeRange: timeRange)
@@ -78,7 +99,9 @@ struct BarChartView: View {
             outageRanges: outageRanges,
             timeRange: timeRange,
             fiveHourVisible: fiveHourVisible,
-            sevenDayVisible: sevenDayVisible
+            sevenDayVisible: sevenDayVisible,
+            fableVisible: fableVisible,
+            fableLabel: fableLabel
         )
         .accessibilityLabel("\(timeRange.displayLabel) bar usage chart")
     }
@@ -153,6 +176,11 @@ struct BarChartView: View {
             let deltaValues = rollups.compactMap(\.extraUsageDelta)
             let extraUsageDelta: Double? = deltaValues.isEmpty ? nil : deltaValues.reduce(0, +)
 
+            // Fable weekly: avg/peak/min, mirroring 5h/7d aggregation
+            let fablePeaks = rollups.compactMap(\.fableWeeklyPeak)
+            let fableAvgs = rollups.compactMap(\.fableWeeklyAvg)
+            let fableMins = rollups.compactMap(\.fableWeeklyMin)
+
             return BarPoint(
                 id: Int(periodStart.timeIntervalSince1970),
                 periodStart: periodStart,
@@ -167,9 +195,37 @@ struct BarChartView: View {
                 resetCount: totalResets,
                 extraUsageSpend: extraUsageSpend,
                 extraUsageUtilization: extraUsageUtil,
-                extraUsageDelta: extraUsageDelta
+                extraUsageDelta: extraUsageDelta,
+                fablePeak: fablePeaks.isEmpty ? nil : fablePeaks.max(),
+                fableAvg: fableAvgs.isEmpty ? nil : fableAvgs.reduce(0, +) / Double(fableAvgs.count),
+                fableMin: fableMins.isEmpty ? nil : fableMins.min()
             )
         }
+    }
+
+    // MARK: - Slot Layout
+
+    /// Computes a bar's start/end offsets (seconds from the period start) for the series
+    /// at `index` of `count` visible series. The period is split into equal slots in
+    /// display order: outermost edges keep 5% padding, adjacent slots are separated by a
+    /// 2% gap on each side. With one or two visible series this reproduces the pre-Fable
+    /// layout exactly. Static for testability (same pattern as `AnalyticsView.hasFableData`).
+    static func slotBounds(index: Int, count: Int, duration: TimeInterval) -> (start: TimeInterval, end: TimeInterval) {
+        let outerPadding = duration * 0.05
+        let innerGap = duration * 0.02
+
+        guard count > 1, index >= 0, index < count else {
+            return (outerPadding, duration - outerPadding)
+        }
+
+        let slotDuration = duration / Double(count)
+        let slotStart = slotDuration * Double(index)
+        let slotEnd = slotDuration * Double(index + 1)
+
+        let leadingInset = index == 0 ? outerPadding : innerGap
+        let trailingInset = index == count - 1 ? outerPadding : innerGap
+
+        return (slotStart + leadingInset, slotEnd - trailingInset)
     }
 
     // MARK: - Gap Detection
@@ -239,6 +295,8 @@ private struct BarChartWithHoverOverlay: View {
     let timeRange: TimeRange
     let fiveHourVisible: Bool
     let sevenDayVisible: Bool
+    let fableVisible: Bool
+    let fableLabel: String
 
     @State private var hoveredIndex: Int?
     /// The resolved cursor date from ChartProxy — used for gap range detection.
@@ -251,7 +309,8 @@ private struct BarChartWithHoverOverlay: View {
             outageRanges: outageRanges,
             timeRange: timeRange,
             fiveHourVisible: fiveHourVisible,
-            sevenDayVisible: sevenDayVisible
+            sevenDayVisible: sevenDayVisible,
+            fableVisible: fableVisible
         )
         .chartOverlay { proxy in
             GeometryReader { geometry in
@@ -283,6 +342,8 @@ private struct BarChartWithHoverOverlay: View {
                         timeRange: timeRange,
                         fiveHourVisible: fiveHourVisible,
                         sevenDayVisible: sevenDayVisible,
+                        fableVisible: fableVisible,
+                        fableLabel: fableLabel,
                         proxy: proxy,
                         size: geometry.size
                     )
@@ -336,42 +397,36 @@ private struct StaticBarChartContent: View {
     let timeRange: TimeRange
     let fiveHourVisible: Bool
     let sevenDayVisible: Bool
-
-    /// Whether both series are visible (determines grouped vs single bar mode).
-    private var bothVisible: Bool {
-        fiveHourVisible && sevenDayVisible
-    }
+    let fableVisible: Bool
 
     private enum Series {
-        case fiveHour, sevenDay
+        case fiveHour, sevenDay, fable
+    }
+
+    /// Visible series in fixed display order (5h, 7d, Fable).
+    private var visibleSeries: [Series] {
+        var result: [Series] = []
+        if fiveHourVisible { result.append(.fiveHour) }
+        if sevenDayVisible { result.append(.sevenDay) }
+        if fableVisible { result.append(.fable) }
+        return result
     }
 
     /// Computes the x-axis start/end dates for a bar, handling grouped vs single mode.
-    ///
-    /// - Single series: bar spans 90% of the period (5% padding on each side).
-    /// - Both series: period split in half with a 4% gap between the two halves.
+    /// Delegates the slot arithmetic to `BarChartView.slotBounds` (unit-tested).
     private func barBounds(for point: BarChartView.BarPoint, series: Series) -> (start: Date, end: Date) {
         let duration = point.periodEnd.timeIntervalSince(point.periodStart)
-        let outerPadding = duration * 0.05
-
-        if bothVisible {
-            let halfDuration = duration * 0.5
-            let innerGap = duration * 0.02
-            switch series {
-            case .fiveHour:
-                let start = point.periodStart.addingTimeInterval(outerPadding)
-                let end = point.periodStart.addingTimeInterval(halfDuration - innerGap)
-                return (start, end)
-            case .sevenDay:
-                let start = point.periodStart.addingTimeInterval(halfDuration + innerGap)
-                let end = point.periodEnd.addingTimeInterval(-outerPadding)
-                return (start, end)
-            }
+        let seriesList = visibleSeries
+        let bounds: (start: TimeInterval, end: TimeInterval)
+        if let index = seriesList.firstIndex(of: series) {
+            bounds = BarChartView.slotBounds(index: index, count: seriesList.count, duration: duration)
         } else {
-            let start = point.periodStart.addingTimeInterval(outerPadding)
-            let end = point.periodEnd.addingTimeInterval(-outerPadding)
-            return (start, end)
+            bounds = BarChartView.slotBounds(index: 0, count: 1, duration: duration)
         }
+        return (
+            point.periodStart.addingTimeInterval(bounds.start),
+            point.periodStart.addingTimeInterval(bounds.end)
+        )
     }
 
     /// Computes the x-axis domain to cover the full selected time range,
@@ -458,6 +513,22 @@ private struct StaticBarChartContent: View {
                             yEnd: .value("Peak", peak)
                         )
                         .foregroundStyle(BarChartView.sevenDayColor)
+                    }
+                }
+            }
+
+            // Fable weekly series bars (indigo)
+            if fableVisible {
+                ForEach(barPoints) { point in
+                    if let peak = point.fablePeak {
+                        let bounds = barBounds(for: point, series: .fable)
+                        RectangleMark(
+                            xStart: .value("Start", bounds.start),
+                            xEnd: .value("End", bounds.end),
+                            yStart: .value("Bottom", 0),
+                            yEnd: .value("Peak", peak)
+                        )
+                        .foregroundStyle(BarChartView.fableColor)
                     }
                 }
             }
@@ -585,6 +656,8 @@ private struct BarHoverOverlayContent: View {
     let timeRange: TimeRange
     let fiveHourVisible: Bool
     let sevenDayVisible: Bool
+    let fableVisible: Bool
+    let fableLabel: String
     let proxy: ChartProxy
     let size: CGSize
 
@@ -697,6 +770,16 @@ private struct BarHoverOverlayContent: View {
                 }
             }
 
+            // Fable series stats
+            if fableVisible, let peak = point.fablePeak {
+                HStack(spacing: 3) {
+                    Circle().fill(BarChartView.fableColor).frame(width: 6, height: 6)
+                    Text(seriesText(label: fableLabel, peak: peak, avg: point.fableAvg))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
             // Min value (lowest across visible series)
             let minValue = computeMinValue(for: point)
             if let minVal = minValue {
@@ -768,6 +851,9 @@ private struct BarHoverOverlayContent: View {
             mins.append(min)
         }
         if sevenDayVisible, let min = point.sevenDayMin {
+            mins.append(min)
+        }
+        if fableVisible, let min = point.fableMin {
             mins.append(min)
         }
         return mins.min()

--- a/cc-hdrm/Views/StepAreaChartView.swift
+++ b/cc-hdrm/Views/StepAreaChartView.swift
@@ -124,6 +124,9 @@ struct OutageTooltipView: View {
 struct StepAreaChartView: View {
     let fiveHourVisible: Bool
     let sevenDayVisible: Bool
+    let fableVisible: Bool
+    /// Display label for the model-scoped (Fable) series — from the live API display name.
+    let fableLabel: String
 
     // Pre-computed in init — never recomputed
     let chartPoints: [ChartPoint]
@@ -131,6 +134,8 @@ struct StepAreaChartView: View {
     let fiveHourPoints: [ChartPoint]
     /// Flat array of points with non-nil sevenDayUtil
     let sevenDayPoints: [ChartPoint]
+    /// Flat array of points with non-nil fableWeeklyUtil
+    let fablePoints: [ChartPoint]
     /// Flat array of points where extra usage is active (delta > 0, prominent layer)
     let extraUsagePoints: [ChartPoint]
     /// Flat array of points where extraUsageUtilization > 0 (faint cumulative background)
@@ -143,6 +148,8 @@ struct StepAreaChartView: View {
 
     /// 7-day series color — distinct blue.
     static let sevenDayColor = Color.blue
+    /// Model-scoped (Fable) weekly series color — distinct from 5h green and 7d blue.
+    static let fableColor = Color.indigo
 
     private static let logger = Logger(
         subsystem: "com.cc-hdrm.app",
@@ -151,9 +158,18 @@ struct StepAreaChartView: View {
 
     // MARK: - Init
 
-    init(polls: [UsagePoll], fiveHourVisible: Bool, sevenDayVisible: Bool, outagePeriods: [OutagePeriod] = []) {
+    init(
+        polls: [UsagePoll],
+        fiveHourVisible: Bool,
+        sevenDayVisible: Bool,
+        fableVisible: Bool = false,
+        fableLabel: String = "Model",
+        outagePeriods: [OutagePeriod] = []
+    ) {
         self.fiveHourVisible = fiveHourVisible
         self.sevenDayVisible = sevenDayVisible
+        self.fableVisible = fableVisible
+        self.fableLabel = fableLabel
 
         let points = Self.makeChartPoints(from: polls)
 
@@ -168,6 +184,7 @@ struct StepAreaChartView: View {
         self.resetTimestamps = Self.findResetTimestamps(in: polls)
         self.fiveHourPoints = cleanedPoints.filter { $0.fiveHourUtil != nil }
         self.sevenDayPoints = cleanedPoints.filter { $0.sevenDayUtil != nil }
+        self.fablePoints = cleanedPoints.filter { $0.fableWeeklyUtil != nil }
         self.extraUsagePoints = cleanedPoints.filter { $0.extraUsageActive == true }
         self.extraUsageBackgroundPoints = cleanedPoints.filter { ($0.extraUsageUtilization ?? 0) > 0 }
         self.gapRanges = Self.findGapRanges(in: cleanedPoints)
@@ -183,7 +200,7 @@ struct StepAreaChartView: View {
     /// of the next segment (where the segment ID differs).
     private static func findGapRanges(in points: [ChartPoint]) -> [GapRange] {
         // Only consider points that have actual data (non-nil utilization)
-        let dataPoints = points.filter { $0.fiveHourUtil != nil || $0.sevenDayUtil != nil }
+        let dataPoints = points.filter { $0.fiveHourUtil != nil || $0.sevenDayUtil != nil || $0.fableWeeklyUtil != nil }
         guard dataPoints.count >= 2 else { return [] }
 
         var gaps: [GapRange] = []
@@ -263,7 +280,8 @@ struct StepAreaChartView: View {
                     extraUsageUsedCredits: nil,
                     extraUsageUtilization: nil,
                     extraUsageMonthlyLimit: nil,
-                    extraUsageDelta: nil
+                    extraUsageDelta: nil,
+                    fableWeeklyUtil: nil
                 )
             }
             return point
@@ -277,13 +295,16 @@ struct StepAreaChartView: View {
             chartPoints: chartPoints,
             fiveHourPoints: fiveHourPoints,
             sevenDayPoints: sevenDayPoints,
+            fablePoints: fablePoints,
             extraUsagePoints: extraUsagePoints,
             extraUsageBackgroundPoints: extraUsageBackgroundPoints,
             resetTimestamps: resetTimestamps,
             gapRanges: gapRanges,
             outageRanges: outageRanges,
             fiveHourVisible: fiveHourVisible,
-            sevenDayVisible: sevenDayVisible
+            sevenDayVisible: sevenDayVisible,
+            fableVisible: fableVisible,
+            fableLabel: fableLabel
         )
         .accessibilityLabel("24-hour step-area usage chart")
     }
@@ -302,6 +323,7 @@ struct StepAreaChartView: View {
         var extraUsageUtilization: Double? = nil
         var extraUsageMonthlyLimit: Double? = nil
         var extraUsageDelta: Double? = nil
+        var fableWeeklyUtil: Double? = nil
     }
 
     /// A time range where no poll data exists (sleep, system off, etc.)
@@ -342,7 +364,8 @@ struct StepAreaChartView: View {
                 extraUsageUsedCredits: poll.extraUsageUsedCredits,
                 extraUsageUtilization: poll.extraUsageUtilization,
                 extraUsageMonthlyLimit: poll.extraUsageMonthlyLimit,
-                extraUsageDelta: poll.extraUsageDelta
+                extraUsageDelta: poll.extraUsageDelta,
+                fableWeeklyUtil: poll.fableWeeklyUtil
             )
         }
     }
@@ -437,6 +460,7 @@ struct StepAreaChartView: View {
         let resetDropThreshold: Double = 10.0
         var maxFiveHour: Double?
         var maxSevenDay: Double?
+        var maxFable: Double?
         var currentSegment = points[0].segment
 
         var result: [ChartPoint] = []
@@ -447,6 +471,7 @@ struct StepAreaChartView: View {
             if point.segment != currentSegment {
                 maxFiveHour = nil
                 maxSevenDay = nil
+                maxFable = nil
                 currentSegment = point.segment
             }
 
@@ -488,7 +513,26 @@ struct StepAreaChartView: View {
                 clampedSeven = nil
             }
 
-            if clampedFive == point.fiveHourUtil && clampedSeven == point.sevenDayUtil {
+            // Fable weekly: independent tracker — its weekly reset is unrelated to 5h/7d resets
+            if let util = point.fableWeeklyUtil, let maxFb = maxFable,
+               maxFb - util >= resetDropThreshold {
+                maxFable = nil
+            }
+
+            let clampedFable: Double?
+            if let util = point.fableWeeklyUtil {
+                if let maxFb = maxFable {
+                    clampedFable = max(util, maxFb)
+                } else {
+                    clampedFable = util
+                }
+                maxFable = clampedFable
+            } else {
+                clampedFable = nil
+            }
+
+            if clampedFive == point.fiveHourUtil && clampedSeven == point.sevenDayUtil
+                && clampedFable == point.fableWeeklyUtil {
                 result.append(point)
             } else {
                 result.append(ChartPoint(
@@ -502,7 +546,8 @@ struct StepAreaChartView: View {
                     extraUsageUsedCredits: point.extraUsageUsedCredits,
                     extraUsageUtilization: point.extraUsageUtilization,
                     extraUsageMonthlyLimit: point.extraUsageMonthlyLimit,
-                    extraUsageDelta: point.extraUsageDelta
+                    extraUsageDelta: point.extraUsageDelta,
+                    fableWeeklyUtil: clampedFable
                 ))
             }
         }
@@ -520,6 +565,7 @@ private struct ChartWithHoverOverlay: View {
     let chartPoints: [StepAreaChartView.ChartPoint]
     let fiveHourPoints: [StepAreaChartView.ChartPoint]
     let sevenDayPoints: [StepAreaChartView.ChartPoint]
+    let fablePoints: [StepAreaChartView.ChartPoint]
     let extraUsagePoints: [StepAreaChartView.ChartPoint]
     let extraUsageBackgroundPoints: [StepAreaChartView.ChartPoint]
     let resetTimestamps: [Date]
@@ -527,6 +573,8 @@ private struct ChartWithHoverOverlay: View {
     let outageRanges: [OutageRange]
     let fiveHourVisible: Bool
     let sevenDayVisible: Bool
+    let fableVisible: Bool
+    let fableLabel: String
 
     @State private var hoveredIndex: Int?
     /// The resolved cursor date from ChartProxy — used for gap range detection.
@@ -536,13 +584,15 @@ private struct ChartWithHoverOverlay: View {
         StaticChartContent(
             fiveHourPoints: fiveHourPoints,
             sevenDayPoints: sevenDayPoints,
+            fablePoints: fablePoints,
             extraUsagePoints: extraUsagePoints,
             extraUsageBackgroundPoints: extraUsageBackgroundPoints,
             resetTimestamps: resetTimestamps,
             gapRanges: gapRanges,
             outageRanges: outageRanges,
             fiveHourVisible: fiveHourVisible,
-            sevenDayVisible: sevenDayVisible
+            sevenDayVisible: sevenDayVisible,
+            fableVisible: fableVisible
         )
         .chartOverlay { proxy in
             GeometryReader { geometry in
@@ -573,6 +623,8 @@ private struct ChartWithHoverOverlay: View {
                         hoveredDate: hoveredDate,
                         fiveHourVisible: fiveHourVisible,
                         sevenDayVisible: sevenDayVisible,
+                        fableVisible: fableVisible,
+                        fableLabel: fableLabel,
                         proxy: proxy,
                         size: geometry.size
                     )
@@ -626,6 +678,7 @@ private struct ChartWithHoverOverlay: View {
 private struct StaticChartContent: View {
     let fiveHourPoints: [StepAreaChartView.ChartPoint]
     let sevenDayPoints: [StepAreaChartView.ChartPoint]
+    let fablePoints: [StepAreaChartView.ChartPoint]
     let extraUsagePoints: [StepAreaChartView.ChartPoint]
     let extraUsageBackgroundPoints: [StepAreaChartView.ChartPoint]
     let resetTimestamps: [Date]
@@ -633,6 +686,7 @@ private struct StaticChartContent: View {
     let outageRanges: [OutageRange]
     let fiveHourVisible: Bool
     let sevenDayVisible: Bool
+    let fableVisible: Bool
 
     var body: some View {
         Chart {
@@ -699,6 +753,21 @@ private struct StaticChartContent: View {
                         series: .value("Seg", "7d-\(point.segment)")
                     )
                     .foregroundStyle(StepAreaChartView.sevenDayColor)
+                    .interpolationMethod(.stepEnd)
+                    .lineStyle(StrokeStyle(lineWidth: 2))
+                }
+            }
+
+            // Fable weekly series: line only (indigo)
+            // series: "fable-N" — separate from 5h/7d and per-segment
+            if fableVisible {
+                ForEach(fablePoints) { point in
+                    LineMark(
+                        x: .value("Time", point.date),
+                        y: .value("Utilization", point.fableWeeklyUtil ?? 0),
+                        series: .value("Seg", "fable-\(point.segment)")
+                    )
+                    .foregroundStyle(StepAreaChartView.fableColor)
                     .interpolationMethod(.stepEnd)
                     .lineStyle(StrokeStyle(lineWidth: 2))
                 }
@@ -794,6 +863,8 @@ private struct HoverOverlayContent: View {
     let hoveredDate: Date?
     let fiveHourVisible: Bool
     let sevenDayVisible: Bool
+    let fableVisible: Bool
+    let fableLabel: String
     let proxy: ChartProxy
     let size: CGSize
 
@@ -874,6 +945,16 @@ private struct HoverOverlayContent: View {
                         .position(x: xPos, y: yPos)
                 }
 
+                // Fable point marker
+                if fableVisible, let util = point.fableWeeklyUtil,
+                   let yPos = proxy.position(forY: util) {
+                    Circle()
+                        .fill(StepAreaChartView.fableColor)
+                        .stroke(Color.white.opacity(0.8), lineWidth: 1)
+                        .frame(width: 8, height: 8)
+                        .position(x: xPos, y: yPos)
+                }
+
                 // Tooltip
                 tooltipView(for: point)
                     .fixedSize()
@@ -921,6 +1002,14 @@ private struct HoverOverlayContent: View {
                 HStack(spacing: 3) {
                     Circle().fill(StepAreaChartView.sevenDayColor).frame(width: 6, height: 6)
                     Text(String(format: "7d: %.1f%%", util))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            if fableVisible, let util = point.fableWeeklyUtil {
+                HStack(spacing: 3) {
+                    Circle().fill(StepAreaChartView.fableColor).frame(width: 6, height: 6)
+                    Text(String(format: "%@: %.1f%%", fableLabel, util))
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }

--- a/cc-hdrm/Views/UsageChart.swift
+++ b/cc-hdrm/Views/UsageChart.swift
@@ -11,6 +11,11 @@ struct UsageChart: View {
     let timeRange: TimeRange
     let fiveHourVisible: Bool
     let sevenDayVisible: Bool
+    /// Whether the model-scoped (Fable) series is visible. Callers pass the effective
+    /// visibility (toggle state AND data presence) so absent data renders identically to today.
+    var fableVisible: Bool = false
+    /// Display label for the Fable series — from the live API display name.
+    var fableLabel: String = "Model"
     let isLoading: Bool
     /// Whether any historical data exists in the database (across all time ranges).
     /// When false and data is empty, shows "No data yet" instead of "No data for this time range".
@@ -25,7 +30,7 @@ struct UsageChart: View {
 
     /// Whether at least one series is toggled on.
     private var anySeriesVisible: Bool {
-        fiveHourVisible || sevenDayVisible
+        fiveHourVisible || sevenDayVisible || fableVisible
     }
 
     var body: some View {
@@ -53,6 +58,8 @@ struct UsageChart: View {
                 polls: pollData,
                 fiveHourVisible: fiveHourVisible,
                 sevenDayVisible: sevenDayVisible,
+                fableVisible: fableVisible,
+                fableLabel: fableLabel,
                 outagePeriods: outagePeriods
             )
         } else {
@@ -61,6 +68,8 @@ struct UsageChart: View {
                 timeRange: timeRange,
                 fiveHourVisible: fiveHourVisible,
                 sevenDayVisible: sevenDayVisible,
+                fableVisible: fableVisible,
+                fableLabel: fableLabel,
                 outagePeriods: outagePeriods
             )
         }

--- a/cc-hdrmTests/Services/DatabaseManagerTests.swift
+++ b/cc-hdrmTests/Services/DatabaseManagerTests.swift
@@ -51,7 +51,7 @@ struct DatabaseManagerTests {
         #expect(manager.indexExists("idx_reset_events_timestamp"))
     }
 
-    @Test("Schema creation sets schema version to current (7)")
+    @Test("Schema creation sets schema version to current (8)")
     func schemaCreationSetsVersion() throws {
         let (manager, path) = makeManager()
         defer { cleanup(manager: manager, path: path) }
@@ -59,7 +59,7 @@ struct DatabaseManagerTests {
         try manager.ensureSchema()
 
         let version = try manager.getSchemaVersion()
-        #expect(version == 7)
+        #expect(version == 8)
     }
 
     @Test("Database path is correct")
@@ -202,7 +202,7 @@ struct DatabaseManagerTests {
         let version2 = try manager2.getSchemaVersion()
 
         #expect(version1 == version2)
-        #expect(version1 == 7)
+        #expect(version1 == 8)
     }
 
     @Test("Migration v1->v2 creates rollup_metadata table")
@@ -289,7 +289,7 @@ struct DatabaseManagerTests {
         #expect(util == 0.99)
 
         // Verify version bumped to current (migration runs all the way through)
-        #expect(try manager2.getSchemaVersion() == 7)
+        #expect(try manager2.getSchemaVersion() == 8)
     }
 
     @Test("Migration v2->v3 adds extra_usage columns to usage_polls")
@@ -376,8 +376,8 @@ struct DatabaseManagerTests {
         sqlite3_finalize(dataStmt)
         #expect(util == 0.88)
 
-        // Verify version bumped to 6
-        #expect(try manager2.getSchemaVersion() == 7)
+        // Verify version bumped to current
+        #expect(try manager2.getSchemaVersion() == 8)
     }
 
     // MARK: - Table Schema Verification (AC #1)
@@ -412,6 +412,8 @@ struct DatabaseManagerTests {
         #expect(columns.contains("extra_usage_used_credits"))
         #expect(columns.contains("extra_usage_utilization"))
         #expect(columns.contains("extra_usage_delta"))
+        #expect(columns.contains("fable_weekly_util"))
+        #expect(columns.contains("fable_weekly_resets_at"))
     }
 
     @Test("usage_rollups table has correct columns")
@@ -448,6 +450,9 @@ struct DatabaseManagerTests {
         #expect(columns.contains("extra_usage_used_credits"))
         #expect(columns.contains("extra_usage_utilization"))
         #expect(columns.contains("extra_usage_delta"))
+        #expect(columns.contains("fable_weekly_avg"))
+        #expect(columns.contains("fable_weekly_peak"))
+        #expect(columns.contains("fable_weekly_min"))
     }
 
     @Test("reset_events table has correct columns")
@@ -603,7 +608,7 @@ struct DatabaseManagerTests {
         let rollupResult = sqlite3_exec(connection2, "INSERT INTO usage_rollups (period_start, period_end, resolution, extra_usage_delta) VALUES (1000, 2000, '5min', 10.5)", nil, nil, &errorMessage)
         #expect(rollupResult == SQLITE_OK, "INSERT with extra_usage_delta into usage_rollups should succeed")
 
-        #expect(try manager2.getSchemaVersion() == 7)
+        #expect(try manager2.getSchemaVersion() == 8)
     }
 
     @Test("Migration v4->v5 backfills deltas from consecutive polls")
@@ -766,7 +771,141 @@ struct DatabaseManagerTests {
         #expect(manager2.tableExists("tpp_measurements"))
         #expect(manager2.indexExists("idx_tpp_timestamp"))
         #expect(manager2.indexExists("idx_tpp_model_source"))
-        #expect(try manager2.getSchemaVersion() == 7)
+        #expect(try manager2.getSchemaVersion() == 8)
+    }
+
+    // MARK: - Story 21.3: Migration v7->v8 (fable weekly columns)
+
+    /// Creates a full v7-schema database at the given connection (all tables, no fable columns).
+    private func createV7Schema(_ connection: OpaquePointer) {
+        sqlite3_exec(connection, """
+            CREATE TABLE IF NOT EXISTS usage_polls (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp INTEGER NOT NULL,
+                five_hour_util REAL,
+                five_hour_resets_at INTEGER,
+                seven_day_util REAL,
+                seven_day_resets_at INTEGER,
+                extra_usage_enabled INTEGER,
+                extra_usage_monthly_limit REAL,
+                extra_usage_used_credits REAL,
+                extra_usage_utilization REAL,
+                extra_usage_delta REAL
+            )
+            """, nil, nil, nil)
+        sqlite3_exec(connection, """
+            CREATE TABLE IF NOT EXISTS usage_rollups (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                period_start INTEGER NOT NULL,
+                period_end INTEGER NOT NULL,
+                resolution TEXT NOT NULL,
+                five_hour_avg REAL,
+                five_hour_peak REAL,
+                five_hour_min REAL,
+                seven_day_avg REAL,
+                seven_day_peak REAL,
+                seven_day_min REAL,
+                reset_count INTEGER DEFAULT 0,
+                waste_credits REAL,
+                extra_usage_used_credits REAL,
+                extra_usage_utilization REAL,
+                extra_usage_delta REAL
+            )
+            """, nil, nil, nil)
+        sqlite3_exec(connection, "CREATE TABLE IF NOT EXISTS reset_events (id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp INTEGER NOT NULL, five_hour_peak REAL, seven_day_util REAL, tier TEXT, used_credits REAL, constrained_credits REAL, waste_credits REAL)", nil, nil, nil)
+        sqlite3_exec(connection, "CREATE TABLE IF NOT EXISTS rollup_metadata (key TEXT PRIMARY KEY, value TEXT)", nil, nil, nil)
+        sqlite3_exec(connection, "CREATE TABLE IF NOT EXISTS api_outages (id INTEGER PRIMARY KEY AUTOINCREMENT, started_at INTEGER NOT NULL, ended_at INTEGER, failure_reason TEXT NOT NULL)", nil, nil, nil)
+        sqlite3_exec(connection, "CREATE TABLE IF NOT EXISTS tpp_measurements (id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp INTEGER NOT NULL, window_start INTEGER, model TEXT NOT NULL, variant TEXT, source TEXT NOT NULL, five_hour_before REAL, five_hour_after REAL, five_hour_delta REAL, seven_day_before REAL, seven_day_after REAL, seven_day_delta REAL, input_tokens INTEGER NOT NULL, output_tokens INTEGER NOT NULL, cache_create_tokens INTEGER NOT NULL DEFAULT 0, cache_read_tokens INTEGER NOT NULL DEFAULT 0, total_raw_tokens INTEGER NOT NULL, tpp_five_hour REAL, tpp_seven_day REAL, confidence TEXT NOT NULL DEFAULT 'high', message_count INTEGER DEFAULT 1)", nil, nil, nil)
+        sqlite3_exec(connection, "PRAGMA user_version = 7", nil, nil, nil)
+    }
+
+    /// Reads ordered column names for a table.
+    private func columnOrder(_ connection: OpaquePointer, table: String) -> [String] {
+        var statement: OpaquePointer?
+        sqlite3_prepare_v2(connection, "PRAGMA table_info(\(table))", -1, &statement, nil)
+        var columns: [String] = []
+        while sqlite3_step(statement) == SQLITE_ROW {
+            if let namePtr = sqlite3_column_text(statement, 1) {
+                columns.append(String(cString: namePtr))
+            }
+        }
+        sqlite3_finalize(statement)
+        return columns
+    }
+
+    @Test("Migration v7->v8 adds fable columns and preserves existing rows with NULL fable values")
+    func migrationV7ToV8AddsFableColumns() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+        let testPath = tempDir.appendingPathComponent("test_\(UUID().uuidString).db")
+
+        let manager1 = DatabaseManager(databasePath: testPath)
+        let connection = try manager1.getConnection()
+        createV7Schema(connection)
+
+        // Insert pre-migration data
+        var errorMessage: UnsafeMutablePointer<CChar>?
+        sqlite3_exec(connection, "INSERT INTO usage_polls (timestamp, five_hour_util) VALUES (777, 0.77)", nil, nil, &errorMessage)
+        sqlite3_exec(connection, "INSERT INTO usage_rollups (period_start, period_end, resolution, five_hour_avg) VALUES (1000, 2000, '5min', 42.0)", nil, nil, &errorMessage)
+
+        manager1.closeConnection()
+
+        // New manager triggers migration
+        let manager2 = DatabaseManager(databasePath: testPath)
+        defer { cleanup(manager: manager2, path: testPath) }
+        try manager2.ensureSchema()
+
+        let connection2 = try manager2.getConnection()
+
+        // New columns accept inserts
+        let pollResult = sqlite3_exec(connection2, "INSERT INTO usage_polls (timestamp, fable_weekly_util, fable_weekly_resets_at) VALUES (999, 63.0, 1754952000000)", nil, nil, &errorMessage)
+        #expect(pollResult == SQLITE_OK, "INSERT with fable columns into usage_polls should succeed")
+        let rollupResult = sqlite3_exec(connection2, "INSERT INTO usage_rollups (period_start, period_end, resolution, fable_weekly_avg, fable_weekly_peak, fable_weekly_min) VALUES (2000, 3000, '5min', 60.0, 65.0, 55.0)", nil, nil, &errorMessage)
+        #expect(rollupResult == SQLITE_OK, "INSERT with fable columns into usage_rollups should succeed")
+
+        // Pre-migration rows survive with NULL fable values
+        var stmt: OpaquePointer?
+        sqlite3_prepare_v2(connection2, "SELECT five_hour_util, fable_weekly_util, fable_weekly_resets_at FROM usage_polls WHERE timestamp = 777", -1, &stmt, nil)
+        #expect(sqlite3_step(stmt) == SQLITE_ROW)
+        #expect(sqlite3_column_double(stmt, 0) == 0.77)
+        #expect(sqlite3_column_type(stmt, 1) == SQLITE_NULL, "Pre-migration poll should have NULL fable_weekly_util")
+        #expect(sqlite3_column_type(stmt, 2) == SQLITE_NULL, "Pre-migration poll should have NULL fable_weekly_resets_at")
+        sqlite3_finalize(stmt)
+
+        sqlite3_prepare_v2(connection2, "SELECT five_hour_avg, fable_weekly_avg FROM usage_rollups WHERE period_start = 1000", -1, &stmt, nil)
+        #expect(sqlite3_step(stmt) == SQLITE_ROW)
+        #expect(sqlite3_column_double(stmt, 0) == 42.0)
+        #expect(sqlite3_column_type(stmt, 1) == SQLITE_NULL, "Pre-migration rollup should have NULL fable_weekly_avg")
+        sqlite3_finalize(stmt)
+
+        #expect(try manager2.getSchemaVersion() == 8)
+    }
+
+    @Test("Migrated v7 database has identical column order to fresh v8 database")
+    func migratedAndFreshSchemasHaveIdenticalColumnOrder() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+
+        // Migrated DB: v7 schema -> migration
+        let migratedPath = tempDir.appendingPathComponent("test_\(UUID().uuidString).db")
+        let migratedSetup = DatabaseManager(databasePath: migratedPath)
+        createV7Schema(try migratedSetup.getConnection())
+        migratedSetup.closeConnection()
+        let migratedManager = DatabaseManager(databasePath: migratedPath)
+        defer { cleanup(manager: migratedManager, path: migratedPath) }
+        try migratedManager.ensureSchema()
+
+        // Fresh DB: created at v8 directly
+        let (freshManager, freshPath) = makeManager()
+        defer { cleanup(manager: freshManager, path: freshPath) }
+        try freshManager.ensureSchema()
+
+        let migratedConn = try migratedManager.getConnection()
+        let freshConn = try freshManager.getConnection()
+
+        for table in ["usage_polls", "usage_rollups"] {
+            let migratedColumns = columnOrder(migratedConn, table: table)
+            let freshColumns = columnOrder(freshConn, table: table)
+            #expect(migratedColumns == freshColumns, "\(table) column order must match between migrated and fresh databases (rows are read positionally)")
+        }
     }
 
     // MARK: - Protocol Conformance

--- a/cc-hdrmTests/Services/HistoricalDataServiceTests.swift
+++ b/cc-hdrmTests/Services/HistoricalDataServiceTests.swift
@@ -1695,6 +1695,283 @@ struct HistoricalDataServiceTests {
         #expect(rollups.count == 1)
         #expect(rollups[0].extraUsageDelta == 7.5, "Raw poll delta should pass through")
     }
+
+    // MARK: - Story 21.3: Fable Weekly Persistence Tests
+
+    private func fableLimitEntry(percent: Double?, resetsAt: String?) -> LimitEntry {
+        LimitEntry(
+            kind: "weekly_scoped",
+            group: nil,
+            percent: percent,
+            severity: nil,
+            resetsAt: resetsAt,
+            isActive: true,
+            scope: LimitScope(model: ScopedModel(id: "claude-fable-5", displayName: "Fable"), surface: nil)
+        )
+    }
+
+    @Test("persistPoll stores fable weekly data from weekly_scoped limit entry")
+    func persistPollStoresFableData() async throws {
+        let (dbManager, path) = makeManager()
+        defer { cleanup(manager: dbManager, path: path) }
+        try dbManager.ensureSchema()
+        let service = HistoricalDataService(databaseManager: dbManager)
+
+        let response = UsageResponse(
+            fiveHour: WindowUsage(utilization: 45.0, resetsAt: nil),
+            sevenDay: nil,
+            limits: [fableLimitEntry(percent: 63.0, resetsAt: "2026-08-12T22:00:00Z")],
+            extraUsage: nil
+        )
+        try await service.persistPoll(response)
+
+        let polls = try await service.getRecentPolls(hours: 1)
+        #expect(polls.count == 1)
+        #expect(polls[0].fableWeeklyUtil == 63.0)
+        // 2026-08-12T22:00:00Z == 1,786,572,000,000 Unix ms (known constant, not derived via production code)
+        #expect(polls[0].fableWeeklyResetsAt == 1_786_572_000_000, "resets_at should be stored in Unix milliseconds")
+    }
+
+    @Test("persistPoll stores NULL fable columns when no weekly_scoped entry")
+    func persistPollStoresNilFableWithoutScopedLimit() async throws {
+        let (dbManager, path) = makeManager()
+        defer { cleanup(manager: dbManager, path: path) }
+        try dbManager.ensureSchema()
+        let service = HistoricalDataService(databaseManager: dbManager)
+
+        // limits nil
+        let responseNoLimits = UsageResponse(
+            fiveHour: WindowUsage(utilization: 45.0, resetsAt: nil),
+            sevenDay: nil, limits: nil, extraUsage: nil
+        )
+        try await service.persistPoll(responseNoLimits)
+
+        // limits present but no weekly_scoped entry
+        let responseOtherKind = UsageResponse(
+            fiveHour: WindowUsage(utilization: 46.0, resetsAt: nil),
+            sevenDay: nil,
+            limits: [LimitEntry(kind: "session", group: nil, percent: 18.0, severity: nil, resetsAt: nil, isActive: nil, scope: nil)],
+            extraUsage: nil
+        )
+        try await service.persistPoll(responseOtherKind)
+
+        let polls = try await service.getRecentPolls(hours: 1)
+        #expect(polls.count == 2)
+        for poll in polls {
+            #expect(poll.fableWeeklyUtil == nil)
+            #expect(poll.fableWeeklyResetsAt == nil)
+        }
+    }
+
+    @Test("persistPoll stores fable util with NULL resets_at when entry has no resets_at")
+    func persistPollStoresFableUtilWithNilResetsAt() async throws {
+        let (dbManager, path) = makeManager()
+        defer { cleanup(manager: dbManager, path: path) }
+        try dbManager.ensureSchema()
+        let service = HistoricalDataService(databaseManager: dbManager)
+
+        let response = UsageResponse(
+            fiveHour: nil,
+            sevenDay: nil,
+            limits: [fableLimitEntry(percent: 42.0, resetsAt: nil)],
+            extraUsage: nil
+        )
+        try await service.persistPoll(response)
+
+        let polls = try await service.getRecentPolls(hours: 1)
+        #expect(polls.count == 1)
+        #expect(polls[0].fableWeeklyUtil == 42.0)
+        #expect(polls[0].fableWeeklyResetsAt == nil)
+    }
+
+    @Test("persistPoll uses the first weekly_scoped entry when multiple are reported")
+    func persistPollUsesFirstScopedEntry() async throws {
+        let (dbManager, path) = makeManager()
+        defer { cleanup(manager: dbManager, path: path) }
+        try dbManager.ensureSchema()
+        let service = HistoricalDataService(databaseManager: dbManager)
+
+        let response = UsageResponse(
+            fiveHour: nil,
+            sevenDay: nil,
+            limits: [
+                fableLimitEntry(percent: 63.0, resetsAt: nil),
+                fableLimitEntry(percent: 99.0, resetsAt: nil)
+            ],
+            extraUsage: nil
+        )
+        try await service.persistPoll(response)
+
+        let polls = try await service.getRecentPolls(hours: 1)
+        #expect(polls.count == 1)
+        #expect(polls[0].fableWeeklyUtil == 63.0, "First weekly_scoped entry wins")
+    }
+
+    @Test("getLastPoll round-trips fable weekly fields")
+    func getLastPollReturnsFableData() async throws {
+        let (dbManager, path) = makeManager()
+        defer { cleanup(manager: dbManager, path: path) }
+        try dbManager.ensureSchema()
+        let service = HistoricalDataService(databaseManager: dbManager)
+
+        let response = UsageResponse(
+            fiveHour: WindowUsage(utilization: 20.0, resetsAt: nil),
+            sevenDay: nil,
+            limits: [fableLimitEntry(percent: 77.5, resetsAt: "2026-08-14T10:00:00Z")],
+            extraUsage: nil
+        )
+        try await service.persistPoll(response)
+
+        let lastPoll = try await service.getLastPoll()
+        #expect(lastPoll?.fableWeeklyUtil == 77.5)
+        // 2026-08-14T10:00:00Z == 1,786,701,600,000 Unix ms (known constant, not derived via production code)
+        #expect(lastPoll?.fableWeeklyResetsAt == 1_786_701_600_000)
+    }
+
+    @Test("Rollup computes fable avg/peak/min; all-NULL bucket stays NULL")
+    func rollupAggregatesFableAvgPeakMin() async throws {
+        let (dbManager, path) = makeManager()
+        defer { cleanup(manager: dbManager, path: path) }
+        try dbManager.ensureSchema()
+        let service = HistoricalDataService(databaseManager: dbManager)
+        let connection = try dbManager.getConnection()
+
+        let baseTimestamp = Int64(Date().timeIntervalSince1970 * 1000) - (25 * 60 * 60 * 1000)
+        let fiveMinutesMs: Int64 = 5 * 60 * 1000
+        let bucketStart = (baseTimestamp / fiveMinutesMs) * fiveMinutesMs
+        let nullBucketStart = bucketStart + 2 * fiveMinutesMs
+
+        var errorMessage: UnsafeMutablePointer<CChar>?
+        // Bucket 1: fable utils 40, 60, 50
+        sqlite3_exec(connection, "INSERT INTO usage_polls (timestamp, five_hour_util, fable_weekly_util) VALUES (\(bucketStart), 50.0, 40.0)", nil, nil, &errorMessage)
+        sqlite3_exec(connection, "INSERT INTO usage_polls (timestamp, five_hour_util, fable_weekly_util) VALUES (\(bucketStart + 30000), 55.0, 60.0)", nil, nil, &errorMessage)
+        sqlite3_exec(connection, "INSERT INTO usage_polls (timestamp, five_hour_util, fable_weekly_util) VALUES (\(bucketStart + 60000), 60.0, 50.0)", nil, nil, &errorMessage)
+        // Bucket 2: no fable data (NULL never becomes 0)
+        sqlite3_exec(connection, "INSERT INTO usage_polls (timestamp, five_hour_util) VALUES (\(nullBucketStart), 70.0)", nil, nil, &errorMessage)
+
+        try await service.ensureRollupsUpToDate()
+
+        let rollups = try await service.getRolledUpData(range: .week)
+        let fableRollup = rollups.first { $0.resolution == .fiveMin && $0.periodStart == bucketStart }
+        #expect(fableRollup != nil, "Expected 5-minute rollup for fable bucket")
+        #expect(fableRollup?.fableWeeklyAvg == 50.0, "Avg of 40/60/50 should be 50")
+        #expect(fableRollup?.fableWeeklyPeak == 60.0)
+        #expect(fableRollup?.fableWeeklyMin == 40.0)
+
+        let nullRollup = rollups.first { $0.resolution == .fiveMin && $0.periodStart == nullBucketStart }
+        #expect(nullRollup != nil, "Expected 5-minute rollup for NULL bucket")
+        #expect(nullRollup?.fableWeeklyAvg == nil, "All-NULL fable bucket must stay NULL, not 0")
+        #expect(nullRollup?.fableWeeklyPeak == nil)
+        #expect(nullRollup?.fableWeeklyMin == nil)
+    }
+
+    @Test("pollToRollup maps fable util into avg/peak/min for last-24h queries")
+    func fableUtilInDayRangeQueryResults() async throws {
+        let (dbManager, path) = makeManager()
+        defer { cleanup(manager: dbManager, path: path) }
+        try dbManager.ensureSchema()
+        let service = HistoricalDataService(databaseManager: dbManager)
+        let connection = try dbManager.getConnection()
+
+        let now = Int64(Date().timeIntervalSince1970 * 1000)
+        var errorMessage: UnsafeMutablePointer<CChar>?
+        sqlite3_exec(connection, "INSERT INTO usage_polls (timestamp, five_hour_util, fable_weekly_util) VALUES (\(now - 60000), 50.0, 63.0)", nil, nil, &errorMessage)
+
+        let rollups = try await service.getRolledUpData(range: .day)
+        #expect(rollups.count == 1)
+        #expect(rollups[0].fableWeeklyAvg == 63.0)
+        #expect(rollups[0].fableWeeklyPeak == 63.0)
+        #expect(rollups[0].fableWeeklyMin == 63.0)
+    }
+
+    @Test("pollsToRollupsWithResets retains fable fields in reset buckets")
+    func fableFieldsSurviveResetBucketReconstruction() async throws {
+        let (dbManager, path) = makeManager()
+        defer { cleanup(manager: dbManager, path: path) }
+        try dbManager.ensureSchema()
+        let service = HistoricalDataService(databaseManager: dbManager)
+        let connection = try dbManager.getConnection()
+
+        let now = Int64(Date().timeIntervalSince1970 * 1000)
+        let pollTimestamp = now - 60000
+        var errorMessage: UnsafeMutablePointer<CChar>?
+        sqlite3_exec(connection, "INSERT INTO usage_polls (timestamp, five_hour_util, fable_weekly_util) VALUES (\(pollTimestamp), 50.0, 63.0)", nil, nil, &errorMessage)
+        // Reset event inside the poll's pseudo-rollup period triggers the reconstruction path
+        sqlite3_exec(connection, "INSERT INTO reset_events (timestamp, five_hour_peak) VALUES (\(pollTimestamp + 1000), 80.0)", nil, nil, &errorMessage)
+
+        let rollups = try await service.getRolledUpData(range: .day)
+        #expect(rollups.count == 1)
+        #expect(rollups[0].resetCount == 1, "Reset event should be counted in the poll's period")
+        #expect(rollups[0].fableWeeklyAvg == 63.0, "Fable fields must survive reset-bucket reconstruction")
+        #expect(rollups[0].fableWeeklyPeak == 63.0)
+        #expect(rollups[0].fableWeeklyMin == 63.0)
+    }
+
+    @Test("5min->hourly and hourly->daily tiers aggregate fable avg/peak/min with NULL passthrough")
+    func fableAggregationAcrossHigherRollupTiers() async throws {
+        let (dbManager, path) = makeManager()
+        defer { cleanup(manager: dbManager, path: path) }
+        try dbManager.ensureSchema()
+        let service = HistoricalDataService(databaseManager: dbManager)
+        let connection = try dbManager.getConnection()
+
+        let nowMs = Int64(Date().timeIntervalSince1970 * 1000)
+        let fiveMinMs: Int64 = 5 * 60 * 1000
+        let hourMs: Int64 = 3_600_000
+        let dayMs: Int64 = 86_400_000
+
+        // 5min rollups ~8 days old (inside the 7d-30d 5min->hourly window)
+        let hourBucketA = ((nowMs - 8 * dayMs) / hourMs) * hourMs
+        let hourBucketB = hourBucketA + hourMs
+        // Hourly rollups ~31-32 days old (inside the 30d+ hourly->daily window)
+        let dayBucketC = ((nowMs - 31 * dayMs) / dayMs) * dayMs
+        let dayBucketD = dayBucketC - dayMs
+
+        var errorMessage: UnsafeMutablePointer<CChar>?
+        let insert = { (sql: String) in
+            let result = sqlite3_exec(connection, sql, nil, nil, &errorMessage)
+            #expect(result == SQLITE_OK)
+        }
+
+        // Bucket A: two 5min rollups with fable values -> hourly avg-of-avgs/max/min
+        insert("INSERT INTO usage_rollups (period_start, period_end, resolution, five_hour_avg, fable_weekly_avg, fable_weekly_peak, fable_weekly_min) VALUES (\(hourBucketA), \(hourBucketA + fiveMinMs), '5min', 30.0, 40.0, 45.0, 35.0)")
+        insert("INSERT INTO usage_rollups (period_start, period_end, resolution, five_hour_avg, fable_weekly_avg, fable_weekly_peak, fable_weekly_min) VALUES (\(hourBucketA + fiveMinMs), \(hourBucketA + 2 * fiveMinMs), '5min', 35.0, 60.0, 65.0, 55.0)")
+        // Bucket B: 5min rollup without fable data -> hourly fable stays NULL
+        insert("INSERT INTO usage_rollups (period_start, period_end, resolution, five_hour_avg) VALUES (\(hourBucketB), \(hourBucketB + fiveMinMs), '5min', 50.0)")
+        // Bucket C: two hourly rollups with fable values -> daily avg-of-avgs/max/min
+        insert("INSERT INTO usage_rollups (period_start, period_end, resolution, five_hour_avg, fable_weekly_avg, fable_weekly_peak, fable_weekly_min) VALUES (\(dayBucketC), \(dayBucketC + hourMs), 'hourly', 30.0, 20.0, 25.0, 15.0)")
+        insert("INSERT INTO usage_rollups (period_start, period_end, resolution, five_hour_avg, fable_weekly_avg, fable_weekly_peak, fable_weekly_min) VALUES (\(dayBucketC + hourMs), \(dayBucketC + 2 * hourMs), 'hourly', 35.0, 40.0, 45.0, 35.0)")
+        // Bucket D: hourly rollup without fable data -> daily fable stays NULL
+        insert("INSERT INTO usage_rollups (period_start, period_end, resolution, five_hour_avg) VALUES (\(dayBucketD), \(dayBucketD + hourMs), 'hourly', 60.0)")
+
+        try await service.ensureRollupsUpToDate()
+
+        let rollups = try await service.getRolledUpData(range: .all)
+
+        let hourlyA = rollups.first { $0.resolution == .hourly && $0.periodStart == hourBucketA }
+        #expect(hourlyA != nil, "Expected hourly rollup for fable bucket A")
+        #expect(hourlyA?.fableWeeklyAvg == 50.0, "Hourly avg-of-avgs of 40/60 should be 50")
+        #expect(hourlyA?.fableWeeklyPeak == 65.0, "Hourly max-of-peaks of 45/65 should be 65")
+        #expect(hourlyA?.fableWeeklyMin == 35.0, "Hourly min-of-mins of 35/55 should be 35")
+
+        let hourlyB = rollups.first { $0.resolution == .hourly && $0.periodStart == hourBucketB }
+        #expect(hourlyB != nil, "Expected hourly rollup for all-NULL bucket B")
+        #expect(hourlyB?.fableWeeklyAvg == nil, "All-NULL fable 5min bucket must stay NULL at hourly tier")
+        #expect(hourlyB?.fableWeeklyPeak == nil)
+        #expect(hourlyB?.fableWeeklyMin == nil)
+
+        let dailyC = rollups.first { $0.resolution == .daily && $0.periodStart == dayBucketC }
+        #expect(dailyC != nil, "Expected daily rollup for fable bucket C")
+        #expect(dailyC?.fableWeeklyAvg == 30.0, "Daily avg-of-avgs of 20/40 should be 30")
+        #expect(dailyC?.fableWeeklyPeak == 45.0, "Daily max-of-peaks of 25/45 should be 45")
+        #expect(dailyC?.fableWeeklyMin == 15.0, "Daily min-of-mins of 15/35 should be 15")
+
+        let dailyD = rollups.first { $0.resolution == .daily && $0.periodStart == dayBucketD }
+        #expect(dailyD != nil, "Expected daily rollup for all-NULL bucket D")
+        #expect(dailyD?.fableWeeklyAvg == nil, "All-NULL fable hourly bucket must stay NULL at daily tier")
+        #expect(dailyD?.fableWeeklyPeak == nil)
+        #expect(dailyD?.fableWeeklyMin == nil)
+    }
 }
 
 // MARK: - Mock DatabaseManager for Graceful Degradation Tests

--- a/cc-hdrmTests/Services/OutageTrackingTests.swift
+++ b/cc-hdrmTests/Services/OutageTrackingTests.swift
@@ -38,7 +38,7 @@ struct DatabaseManagerOutageTests {
 
         try manager.ensureSchema()
 
-        #expect(try manager.getSchemaVersion() == 7)
+        #expect(try manager.getSchemaVersion() == 8)
     }
 
     @Test("Migration v5->v6 creates api_outages table and index")
@@ -131,7 +131,7 @@ struct DatabaseManagerOutageTests {
         sqlite3_finalize(stmt)
 
         // Verify version bumped to current
-        #expect(try manager2.getSchemaVersion() == 7)
+        #expect(try manager2.getSchemaVersion() == 8)
     }
 
     @Test("api_outages table has correct columns")

--- a/cc-hdrmTests/Views/AnalyticsViewTests.swift
+++ b/cc-hdrmTests/Views/AnalyticsViewTests.swift
@@ -272,11 +272,12 @@ struct AnalyticsViewSeriesToggleTests {
 
     // MARK: - 4.1 Both series visible by default for any TimeRange key
 
-    @Test("SeriesVisibility defaults both series to visible")
+    @Test("SeriesVisibility defaults all series to visible")
     func bothSeriesVisibleByDefault() {
         let visibility = AnalyticsView.SeriesVisibility()
         #expect(visibility.fiveHour == true)
         #expect(visibility.sevenDay == true)
+        #expect(visibility.fable == true)
     }
 
     @Test("Empty dictionary lookup defaults to both-visible for any range")
@@ -394,8 +395,129 @@ struct AnalyticsViewSeriesToggleTests {
         let a = AnalyticsView.SeriesVisibility(fiveHour: true, sevenDay: false)
         let b = AnalyticsView.SeriesVisibility(fiveHour: true, sevenDay: false)
         let c = AnalyticsView.SeriesVisibility(fiveHour: false, sevenDay: false)
+        let d = AnalyticsView.SeriesVisibility(fiveHour: true, sevenDay: false, fable: false)
         #expect(a == b)
         #expect(a != c)
+        #expect(a != d, "fable field participates in equality")
+    }
+
+    // MARK: - Story 21.3: Fable Toggle State
+
+    @Test("toggling fable off for .day persists after switching to .week and back")
+    func fableOffPersistsAcrossRangeSwitch() {
+        var dict: [TimeRange: AnalyticsView.SeriesVisibility] = [:]
+
+        dict[.day, default: AnalyticsView.SeriesVisibility()].fable = false
+
+        // Switch to .week — unaffected
+        let weekVis = dict[.week] ?? AnalyticsView.SeriesVisibility()
+        #expect(weekVis.fable == true)
+
+        // Switch back to .day — fable still off, other series untouched
+        let dayVis = dict[.day] ?? AnalyticsView.SeriesVisibility()
+        #expect(dayVis.fable == false, "fable should remain off for .day after range switch")
+        #expect(dayVis.fiveHour == true)
+        #expect(dayVis.sevenDay == true)
+    }
+
+    @Test("unvisited ranges default fable to visible")
+    func unvisitedRangesDefaultFableVisible() {
+        var dict: [TimeRange: AnalyticsView.SeriesVisibility] = [:]
+        dict[.day, default: AnalyticsView.SeriesVisibility()].fable = false
+
+        for range in [TimeRange.week, .month, .all] {
+            let vis = dict[range] ?? AnalyticsView.SeriesVisibility()
+            #expect(vis.fable == true, "fable should default true for unvisited \(range)")
+        }
+    }
+
+    // MARK: - Story 21.3: Fable Label Fallback
+
+    @Test("fableLabel falls back to Model for nil, empty, and blank display names")
+    func fableLabelFallback() {
+        #expect(AnalyticsView.fableLabel(from: "Fable") == "Fable")
+        #expect(AnalyticsView.fableLabel(from: nil) == "Model")
+        #expect(AnalyticsView.fableLabel(from: "") == "Model", "Empty display name must not render a blank chip label")
+        #expect(AnalyticsView.fableLabel(from: "   ") == "Model", "Blank display name must not render a blank chip label")
+        #expect(AnalyticsView.fableLabel(from: "  Fable  ") == "Fable", "Label is trimmed")
+    }
+
+    // MARK: - Story 21.3: Fable Data Presence (chip gating)
+
+    @Test("hasFableData is false for empty data and data without fable values")
+    func hasFableDataFalseWithoutFableValues() {
+        #expect(AnalyticsView.hasFableData(polls: [], rollups: []) == false)
+
+        let nowMs = Int64(Date().timeIntervalSince1970 * 1000)
+        let polls = [
+            UsagePoll(id: 1, timestamp: nowMs, fiveHourUtil: 50.0, fiveHourResetsAt: nil,
+                      sevenDayUtil: 25.0, sevenDayResetsAt: nil)
+        ]
+        let rollups = [
+            UsageRollup(id: 1, periodStart: nowMs - 300_000, periodEnd: nowMs,
+                        resolution: .fiveMin,
+                        fiveHourAvg: 30.0, fiveHourPeak: 45.0, fiveHourMin: 20.0,
+                        sevenDayAvg: 15.0, sevenDayPeak: 25.0, sevenDayMin: 10.0,
+                        resetCount: 0, unusedCredits: nil)
+        ]
+        #expect(AnalyticsView.hasFableData(polls: polls, rollups: rollups) == false,
+                "All-NULL fable columns must not surface the chip")
+    }
+
+    @Test("Fable history appears in analytics data after one persisted poll cycle")
+    func fableHistoryAppearsAfterOnePollCycle() async throws {
+        // Integration path: real HistoricalDataService + DatabaseManager on a temp DB,
+        // persistPoll -> fetchData, mirroring the epic's success criterion.
+        let tempDir = FileManager.default.temporaryDirectory
+        let testPath = tempDir.appendingPathComponent("test_\(UUID().uuidString).db")
+        let dbManager = DatabaseManager(databasePath: testPath)
+        defer {
+            dbManager.closeConnection()
+            try? FileManager.default.removeItem(at: testPath)
+        }
+        try dbManager.ensureSchema()
+        let service = HistoricalDataService(databaseManager: dbManager)
+
+        let response = UsageResponse(
+            fiveHour: WindowUsage(utilization: 45.0, resetsAt: nil),
+            sevenDay: WindowUsage(utilization: 20.0, resetsAt: nil),
+            limits: [
+                LimitEntry(
+                    kind: "weekly_scoped",
+                    group: nil,
+                    percent: 63.0,
+                    severity: nil,
+                    resetsAt: "2026-08-12T22:00:00Z",
+                    isActive: true,
+                    scope: LimitScope(model: ScopedModel(id: "claude-fable-5", displayName: "Fable"), surface: nil)
+                )
+            ],
+            extraUsage: nil
+        )
+        try await service.persistPoll(response)
+
+        let result = try await AnalyticsView.fetchData(for: .day, using: service, existingAllTimeEvents: nil)
+
+        #expect(result.chartData.count == 1, "One persisted poll cycle should surface one chart data point")
+        #expect(result.chartData.first?.fableWeeklyUtil == 63.0, "Fable utilization must ride the analytics data path")
+        #expect(AnalyticsView.hasFableData(polls: result.chartData, rollups: result.rollupData) == true,
+                "The Fable chip gate must open after one poll cycle with a scoped limit")
+    }
+
+    @Test("hasFableData is true when any poll or rollup carries a fable value")
+    func hasFableDataTrueWithFableValues() {
+        let nowMs = Int64(Date().timeIntervalSince1970 * 1000)
+        let fablePoll = UsagePoll(id: 1, timestamp: nowMs, fiveHourUtil: 50.0, fiveHourResetsAt: nil,
+                                  sevenDayUtil: nil, sevenDayResetsAt: nil, fableWeeklyUtil: 63.0)
+        #expect(AnalyticsView.hasFableData(polls: [fablePoll], rollups: []) == true)
+
+        let fableRollup = UsageRollup(id: 1, periodStart: nowMs - 300_000, periodEnd: nowMs,
+                                      resolution: .fiveMin,
+                                      fiveHourAvg: 30.0, fiveHourPeak: 45.0, fiveHourMin: 20.0,
+                                      sevenDayAvg: nil, sevenDayPeak: nil, sevenDayMin: nil,
+                                      resetCount: 0, unusedCredits: nil,
+                                      fableWeeklyAvg: 60.0, fableWeeklyPeak: 65.0, fableWeeklyMin: 55.0)
+        #expect(AnalyticsView.hasFableData(polls: [], rollups: [fableRollup]) == true)
     }
 
     // MARK: - Binding get/set closure verification (Code Review M1)

--- a/cc-hdrmTests/Views/UsageChartTests.swift
+++ b/cc-hdrmTests/Views/UsageChartTests.swift
@@ -14,6 +14,7 @@ struct UsageChartTests {
         timeRange: TimeRange = .week,
         fiveHourVisible: Bool = true,
         sevenDayVisible: Bool = true,
+        fableVisible: Bool = false,
         isLoading: Bool = false,
         hasAnyHistoricalData: Bool = true,
         outagePeriods: [OutagePeriod] = []
@@ -24,6 +25,7 @@ struct UsageChartTests {
             timeRange: timeRange,
             fiveHourVisible: fiveHourVisible,
             sevenDayVisible: sevenDayVisible,
+            fableVisible: fableVisible,
             isLoading: isLoading,
             hasAnyHistoricalData: hasAnyHistoricalData,
             outagePeriods: outagePeriods
@@ -1259,6 +1261,261 @@ struct UsageChartTests {
         let barPoints = BarChartView.makeBarPoints(from: rollups, timeRange: .week)
         #expect(barPoints.count == 1)
         #expect(barPoints[0].extraUsageSpend == nil)
+    }
+
+    // MARK: - Story 21.3: Fable Weekly Series
+
+    @Test("makeChartPoints carries fableWeeklyUtil from polls")
+    func chartPointsCarryFableUtil() {
+        let nowMs = Int64(Date().timeIntervalSince1970 * 1000)
+        let polls = [
+            UsagePoll(id: 1, timestamp: nowMs - 30_000, fiveHourUtil: 30.0,
+                      fiveHourResetsAt: nil, sevenDayUtil: 20.0, sevenDayResetsAt: nil,
+                      fableWeeklyUtil: 63.0),
+            UsagePoll(id: 2, timestamp: nowMs, fiveHourUtil: 31.0,
+                      fiveHourResetsAt: nil, sevenDayUtil: 21.0, sevenDayResetsAt: nil)
+        ]
+        let points = StepAreaChartView.makeChartPoints(from: polls)
+        #expect(points.count == 2)
+        #expect(points[0].fableWeeklyUtil == 63.0)
+        #expect(points[1].fableWeeklyUtil == nil)
+    }
+
+    @Test("StepAreaChartView filters fablePoints to non-nil fable values")
+    func fablePointsFiltered() {
+        let nowMs = Int64(Date().timeIntervalSince1970 * 1000)
+        var polls: [UsagePoll] = []
+        for i in 0..<10 {
+            polls.append(UsagePoll(
+                id: Int64(i), timestamp: nowMs - Int64(9 - i) * 30_000,
+                fiveHourUtil: 30.0, fiveHourResetsAt: nil,
+                sevenDayUtil: 20.0, sevenDayResetsAt: nil,
+                fableWeeklyUtil: i < 5 ? nil : 40.0 + Double(i)
+            ))
+        }
+        let view = StepAreaChartView(
+            polls: polls,
+            fiveHourVisible: true,
+            sevenDayVisible: true,
+            fableVisible: true,
+            fableLabel: "Fable"
+        )
+        #expect(view.fablePoints.count == 5, "Only points with non-nil fable util belong to the fable series")
+        let _ = view.body
+    }
+
+    @Test("Series line starts partway through window when fable data begins mid-range")
+    func fableSeriesStartsPartwayThroughWindow() {
+        // Pre-migration boundary: NULLs before, values after — fable's own filtered
+        // array starts where the data starts; the 5h/7d series are unaffected.
+        let nowMs = Int64(Date().timeIntervalSince1970 * 1000)
+        var polls: [UsagePoll] = []
+        for i in 0..<20 {
+            polls.append(UsagePoll(
+                id: Int64(i), timestamp: nowMs - Int64(19 - i) * 30_000,
+                fiveHourUtil: 30.0 + Double(i), fiveHourResetsAt: nil,
+                sevenDayUtil: nil, sevenDayResetsAt: nil,
+                fableWeeklyUtil: i >= 10 ? 50.0 + Double(i) : nil
+            ))
+        }
+        let view = StepAreaChartView(
+            polls: polls,
+            fiveHourVisible: true,
+            sevenDayVisible: true,
+            fableVisible: true
+        )
+        #expect(view.fiveHourPoints.count == 20)
+        #expect(view.fablePoints.count == 10)
+        #expect(view.gapRanges.isEmpty, "Missing fable values alone must not create gaps when 5h data is continuous")
+    }
+
+    @Test("Fable-only polls participate in gap detection")
+    func fableOnlyPollsDriveGapDetection() {
+        let nowMs = Int64(Date().timeIntervalSince1970 * 1000)
+        let intervalMs: Int64 = 60_000
+
+        func fableOnlyPoll(id: Int, timestamp: Int64) -> UsagePoll {
+            UsagePoll(id: Int64(id), timestamp: timestamp,
+                      fiveHourUtil: nil, fiveHourResetsAt: nil,
+                      sevenDayUtil: nil, sevenDayResetsAt: nil,
+                      fableWeeklyUtil: 40.0 + Double(id))
+        }
+
+        // Continuous fable-only data (1 min spacing) — no gaps
+        let continuous = (0..<10).map { i in
+            fableOnlyPoll(id: i, timestamp: nowMs - Int64(9 - i) * intervalMs)
+        }
+        let continuousView = StepAreaChartView(
+            polls: continuous, fiveHourVisible: false, sevenDayVisible: false, fableVisible: true
+        )
+        #expect(continuousView.gapRanges.isEmpty, "Continuous fable-only data must not produce gaps")
+
+        // Two fable-only clusters separated by 2h (> 60 min gap threshold) — one gap
+        let gapMs: Int64 = 2 * 3_600_000
+        let firstCluster = (0..<10).map { i in
+            fableOnlyPoll(id: i, timestamp: nowMs - gapMs - Int64(19 - i) * intervalMs)
+        }
+        let secondCluster = (0..<10).map { i in
+            fableOnlyPoll(id: 10 + i, timestamp: nowMs - Int64(9 - i) * intervalMs)
+        }
+        let gappedView = StepAreaChartView(
+            polls: firstCluster + secondCluster, fiveHourVisible: false, sevenDayVisible: false, fableVisible: true
+        )
+        #expect(gappedView.gapRanges.count == 1, "A real time gap in fable-only data must produce a gap range")
+    }
+
+    @Test("enforceMonotonicWithinSegments clamps fable dips and resets on weekly reset drop")
+    func monotonicClampAppliesToFable() {
+        let nowMs = Int64(Date().timeIntervalSince1970 * 1000)
+        let utils: [Double] = [50.0, 49.5, 51.0, 5.0, 6.0] // noise dip, then real reset
+        let polls = utils.enumerated().map { i, util in
+            UsagePoll(id: Int64(i), timestamp: nowMs - Int64(utils.count - 1 - i) * 30_000,
+                      fiveHourUtil: nil, fiveHourResetsAt: nil,
+                      sevenDayUtil: nil, sevenDayResetsAt: nil,
+                      fableWeeklyUtil: util)
+        }
+        let points = StepAreaChartView.enforceMonotonicWithinSegments(
+            StepAreaChartView.makeChartPoints(from: polls)
+        )
+        #expect(points[1].fableWeeklyUtil == 50.0, "Noise dip should clamp to running max")
+        #expect(points[2].fableWeeklyUtil == 51.0)
+        #expect(points[3].fableWeeklyUtil == 5.0, "Large drop is a weekly reset — tracker resets")
+        #expect(points[4].fableWeeklyUtil == 6.0)
+    }
+
+    @Test("makeBarPoints aggregates fable avg/peak/min across rollups")
+    func barPointsAggregateFable() {
+        let nowMs = Int64(Date().timeIntervalSince1970 * 1000)
+        let calendar = Calendar.current
+        let hourStart = calendar.dateInterval(
+            of: .hour,
+            for: Date(timeIntervalSince1970: Double(nowMs) / 1000.0)
+        )!.start
+        let hourStartMs = Int64(hourStart.timeIntervalSince1970 * 1000)
+        let fiveMinMs: Int64 = 300_000
+
+        let rollups = [
+            UsageRollup(
+                id: 1, periodStart: hourStartMs, periodEnd: hourStartMs + fiveMinMs,
+                resolution: .fiveMin,
+                fiveHourAvg: 30.0, fiveHourPeak: 45.0, fiveHourMin: 20.0,
+                sevenDayAvg: 15.0, sevenDayPeak: 25.0, sevenDayMin: 10.0,
+                resetCount: 0, unusedCredits: nil,
+                fableWeeklyAvg: 40.0, fableWeeklyPeak: 45.0, fableWeeklyMin: 35.0
+            ),
+            UsageRollup(
+                id: 2, periodStart: hourStartMs + fiveMinMs, periodEnd: hourStartMs + 2 * fiveMinMs,
+                resolution: .fiveMin,
+                fiveHourAvg: 35.0, fiveHourPeak: 50.0, fiveHourMin: 25.0,
+                sevenDayAvg: 18.0, sevenDayPeak: 30.0, sevenDayMin: 12.0,
+                resetCount: 0, unusedCredits: nil,
+                fableWeeklyAvg: 60.0, fableWeeklyPeak: 65.0, fableWeeklyMin: 55.0
+            ),
+        ]
+
+        let barPoints = BarChartView.makeBarPoints(from: rollups, timeRange: .week)
+        #expect(barPoints.count == 1)
+        #expect(barPoints[0].fableAvg == 50.0, "Avg of 40/60 should be 50")
+        #expect(barPoints[0].fablePeak == 65.0)
+        #expect(barPoints[0].fableMin == 35.0)
+    }
+
+    @Test("BarPoint fable fields default to nil when rollups carry no fable data")
+    func barPointFableDefaultNil() {
+        let nowMs = Int64(Date().timeIntervalSince1970 * 1000)
+        let rollups = [
+            UsageRollup(
+                id: 1, periodStart: nowMs - 300_000, periodEnd: nowMs,
+                resolution: .fiveMin,
+                fiveHourAvg: 30.0, fiveHourPeak: 45.0, fiveHourMin: 20.0,
+                sevenDayAvg: 15.0, sevenDayPeak: 25.0, sevenDayMin: 10.0,
+                resetCount: 0, unusedCredits: nil
+            )
+        ]
+        let barPoints = BarChartView.makeBarPoints(from: rollups, timeRange: .week)
+        #expect(barPoints.count == 1)
+        #expect(barPoints[0].fablePeak == nil)
+        #expect(barPoints[0].fableAvg == nil)
+        #expect(barPoints[0].fableMin == nil)
+    }
+
+    @Test("slotBounds reproduces the original single-series and two-series layout exactly")
+    func slotBoundsMatchesLegacyLayout() {
+        let duration: TimeInterval = 3600
+        let outerPadding = duration * 0.05  // 180
+        let innerGap = duration * 0.02      // 72
+        let half = duration * 0.5           // 1800
+
+        // Single series: 90% span with 5% padding each side
+        let single = BarChartView.slotBounds(index: 0, count: 1, duration: duration)
+        #expect(single.start == outerPadding)
+        #expect(single.end == duration - outerPadding)
+
+        // Two series: original formula — A: [outer, half - gap], B: [half + gap, duration - outer]
+        let first = BarChartView.slotBounds(index: 0, count: 2, duration: duration)
+        #expect(first.start == outerPadding)
+        #expect(first.end == half - innerGap)
+        let second = BarChartView.slotBounds(index: 1, count: 2, duration: duration)
+        #expect(second.start == half + innerGap)
+        #expect(second.end == duration - outerPadding)
+    }
+
+    @Test("slotBounds with three series produces ordered, non-overlapping slots within the period")
+    func slotBoundsThreeSeriesNoOverlap() {
+        let duration: TimeInterval = 3600
+        let slots = (0..<3).map { BarChartView.slotBounds(index: $0, count: 3, duration: duration) }
+
+        #expect(slots[0].start == duration * 0.05, "First slot keeps the 5% outer padding")
+        #expect(slots[2].end == duration - duration * 0.05, "Last slot keeps the 5% outer padding")
+
+        for slot in slots {
+            #expect(slot.start < slot.end, "Each slot must have positive width")
+            #expect(slot.start >= 0 && slot.end <= duration, "Slots stay inside the period")
+        }
+        #expect(slots[0].end < slots[1].start, "Slots 0 and 1 must not overlap")
+        #expect(slots[1].end < slots[2].start, "Slots 1 and 2 must not overlap")
+    }
+
+    @Test("BarChartView renders without crash with all three series visible")
+    func barChartRendersWithFableSeries() {
+        let nowMs = Int64(Date().timeIntervalSince1970 * 1000)
+        let rollups = [
+            UsageRollup(
+                id: 1, periodStart: nowMs - 300_000, periodEnd: nowMs,
+                resolution: .fiveMin,
+                fiveHourAvg: 30.0, fiveHourPeak: 45.0, fiveHourMin: 20.0,
+                sevenDayAvg: 15.0, sevenDayPeak: 25.0, sevenDayMin: 10.0,
+                resetCount: 0, unusedCredits: nil,
+                fableWeeklyAvg: 60.0, fableWeeklyPeak: 65.0, fableWeeklyMin: 55.0
+            )
+        ]
+        let view = BarChartView(
+            rollups: rollups,
+            timeRange: .week,
+            fiveHourVisible: true,
+            sevenDayVisible: true,
+            fableVisible: true,
+            fableLabel: "Fable"
+        )
+        let _ = view.body
+    }
+
+    @Test("UsageChart with only fable visible renders chart, not the no-series message")
+    func usageChartFableOnlyVisible() {
+        let polls = [
+            UsagePoll(id: 1, timestamp: Int64(Date().timeIntervalSince1970 * 1000),
+                      fiveHourUtil: 30.0, fiveHourResetsAt: nil,
+                      sevenDayUtil: 20.0, sevenDayResetsAt: nil,
+                      fableWeeklyUtil: 63.0)
+        ]
+        let chart = makeChart(
+            pollData: polls,
+            timeRange: .day,
+            fiveHourVisible: false,
+            sevenDayVisible: false,
+            fableVisible: true
+        )
+        let _ = chart.body
     }
 
     // MARK: - Issue #66 / #39 / #40 Regression Tests


### PR DESCRIPTION
## Summary

Story 21.3 of Epic 21 (Fable Model Usage Tracking): persist model-scoped weekly cap data and surface it as a series in the analytics window.

- **Schema v7 to v8** (additive only): `fable_weekly_util` + `fable_weekly_resets_at` on `usage_polls`; `fable_weekly_avg/peak/min` on `usage_rollups`. Old rows survive with NULLs; fresh and migrated databases have identical column ordering.
- **Persistence**: every poll stores the first `weekly_scoped` entry from the API response, via a shared `UsageResponse.weeklyScopedEntries` helper also used by the live popover path (single source for the filter, no drift).
- **Rollups**: fable avg/peak/min aggregated through all three tiers (raw to 5min to hourly to daily), including the reset-bucket reconstruction path.
- **Analytics window**: new Fable series — indigo line in the 24h step-area chart, indigo bars in rollup ranges — behind a toggle chip following the existing 5h/7d pattern (session-only, per time range). Chip is labeled from the API's display name (generic fallback for nil/empty) and hidden entirely when no Fable data exists.
- **Quiet degradation**: accounts without a scoped limit see zero change anywhere — no chip, no series, no behavior difference.
- Bar layout generalized from the hardcoded 2-series split to N visible series; verified algebraically identical for 1 and 2 series and pinned by unit tests on the extracted slot math.

## Review

Adversarial 4-layer review (blind hunter, edge-case hunter, verification-gap, intent-alignment): 9 findings patched (3 medium — all test-coverage gaps, now closed; 6 low), 1 pre-existing issue deferred (non-transactional migration blocks), 14 rejected as noise. Full triage log in the story spec.

## Testing

- Full suite: **1520 tests in 129 suites, 0 failures** (25+ new tests).
- Migration v7 to v8 test with NULL preservation and fresh-vs-migrated column-order parity.
- End-to-end test of the epic success criterion: persistPoll with a scoped limit, then AnalyticsView.fetchData shows Fable data ("Fable history appears after one poll cycle").
- Post-merge with latest master: build + full suite re-verified.