### PR TITLE
test: make chronicUnderpowering fixture date-independent

### DIFF
--- a/cc-hdrmTests/Services/SubscriptionPatternDetectorTests.swift
+++ b/cc-hdrmTests/Services/SubscriptionPatternDetectorTests.swift
@@ -288,9 +288,10 @@ struct SubscriptionPatternDetectorTests {
 
     @Test("chronicUnderpowering detected when rate-limited N+ times for 2+ cycles")
     func chronicUnderpoweringDetected() async throws {
-        // Create polls showing frequent rate-limiting over 2 months
+        // 90 days guarantees two complete months after the detector drops the current partial month,
+        // whatever today's date is (a 60-day span leaves the older month partial from mid-month on)
         var polls: [UsagePoll] = []
-        for day in 0..<60 {
+        for day in 0..<90 {
             if day % 5 == 0 {
                 // Rate-limited poll every 5 days
                 polls.append(makePoll(daysAgo: day, fiveHourUtil: 100.0))


### PR DESCRIPTION
## Summary

Fixes the CI failure `SubscriptionPatternDetectorTests/chronicUnderpoweringDetected` that appears from roughly the 15th of every month.

**Cause:** `SubscriptionPatternDetector.detectChronicUnderpowering` drops the current partial month and evaluates the two most recent *complete* months (`rateLimitThreshold = 3` each). The test's 60-day fixture, rate-limited every 5th day, leaves the older of those two months partial once we're past mid-month, so it dips below 3 events and detection is (correctly, for that data) skipped.

**Fix:** span the fixture over 90 days, matching the detector's own 90-day query window. Both evaluated months are then always complete, on any calendar day. Test-only change; no production code touched.

## Verification

- `SubscriptionPatternDetectorTests`: 17/17 pass locally on 2026-08-16 (a date that previously failed).