### PR TITLE
[minor] docs: README — Fable model usage tracking (release 1.6.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Like iStat Menus for your Claude subscription. A macOS menu bar app that shows y
 
 <p align="center">
   <img src="docs/images/demo.gif" alt="cc-hdrm popover showing ring gauges and extra usage bar, and analytics window with 24h, 7d, 30d, and All time range charts" width="640">
+  <br>
+  <sub>Demo recorded before model-scoped caps — the popover now also shows a gauge for per-model weekly limits such as Claude Fable 5.</sub>
 </p>
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -27,19 +27,20 @@ Claude Pro and Max subscribers have no passive way to see how much capacity they
 
 - **Ring gauges** — 5-hour and 7-day headroom with animated fill and slope indicators
 - **Reset countdowns** — relative ("resets in 2h 13m") and absolute ("at 4:52 PM")
+- **Model-scoped caps** — separate gauge for per-model weekly limits (such as Claude Fable 5's weekly cap), labeled from the API with its own reset countdown; hidden when your plan reports none
 - **Extra usage tracking** — dollar-based spend vs. limit with color-coded progress bar
 - **24-hour sparkline** — step-area chart of recent usage; click to open analytics
 
 ### Analytics
 
-- **Historical charts** — 24h, 7d, 30d, and All views with step-area and bar chart visualizations
+- **Historical charts** — 24h, 7d, 30d, and All views with step-area and bar chart visualizations, plus a toggleable series for model-scoped caps
 - **Subscription value breakdown** — used vs. unused dollars prorated from your monthly plan
 - **Pattern detection** — identifies overpaying, underpowering, usage decay, and suggests tier changes
 - **Self-benchmarking** — cycle-over-cycle comparison across billing periods
 
 ### Notifications
 
-- **Threshold alerts** — configurable warnings at customizable headroom levels for both 5h and 7d windows
+- **Threshold alerts** — configurable warnings at customizable headroom levels for the 5h, 7d, and model-scoped windows
 - **Extra usage alerts** — notifications at 50%, 75%, 90% of extra usage credit
 - **Smart re-arming** — thresholds reset when headroom recovers
 
@@ -101,7 +102,7 @@ sequenceDiagram
         A->>K: Read OAuth credentials
         K-->>A: Access token + refresh token
         A->>API: GET /api/oauth/usage
-        API-->>A: Quota data (5h, 7d)
+        API-->>A: Quota data (5h, 7d, model-scoped limits)
         A->>A: Compute headroom, slope, update display
         A->>DB: Persist poll snapshot
     end

--- a/cc-hdrm/Info.plist
+++ b/cc-hdrm/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.5.1</string>
+	<string>1.6.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>

--- a/cc-hdrm/Services/TPPChartDataService.swift
+++ b/cc-hdrm/Services/TPPChartDataService.swift
@@ -105,14 +105,21 @@ final class TPPChartDataService: TPPChartDataServiceProtocol, Sendable {
             from: 0, to: nowMs, source: nil, model: nil, confidence: nil
         )
 
-        // Count occurrences per model
+        // Most recently measured model first, so the picker (and its default) tracks
+        // what the user is using now rather than what has the most history
+        var latestTimestamp: [String: Int64] = [:]
         var modelCounts: [String: Int] = [:]
         for m in allMeasurements {
+            latestTimestamp[m.model] = max(latestTimestamp[m.model] ?? 0, m.timestamp)
             modelCounts[m.model, default: 0] += 1
         }
 
-        // Sort by count descending
-        return modelCounts.sorted { $0.value > $1.value }.map(\.key)
+        return latestTimestamp.keys.sorted { a, b in
+            if latestTimestamp[a]! != latestTimestamp[b]! {
+                return latestTimestamp[a]! > latestTimestamp[b]!
+            }
+            return modelCounts[a]! > modelCounts[b]!
+        }
     }
 
     // MARK: - Chart Point Conversion

--- a/cc-hdrm/Views/TPPSectionView.swift
+++ b/cc-hdrm/Views/TPPSectionView.swift
@@ -245,7 +245,7 @@ struct TPPSectionView: View {
                 model: selectedModel
             )
 
-            // Default to the most-used model if none selected
+            // Default to the most recently measured model if none selected
             if selectedModel == nil, let firstModel = chartData.availableModels.first {
                 selectedModel = firstModel
             }

--- a/cc-hdrmTests/Services/TPPChartDataServiceTests.swift
+++ b/cc-hdrmTests/Services/TPPChartDataServiceTests.swift
@@ -260,24 +260,36 @@ struct TPPChartDataServiceTests {
 
     // MARK: - Model Discovery
 
-    @Test("Model discovery: mixed models sorted by frequency descending")
+    @Test("Model discovery: models sorted by most recent measurement, newest first")
     func modelDiscovery() async throws {
         let storage = MockChartTPPStorage()
-        // Add 5 sonnet, 3 opus, 1 haiku
-        for i in 0..<5 {
-            storage.measurements.append(makeMeasurement(timestamp: nowMs - Int64(i) * oneHourMs, model: "claude-sonnet-4-6"))
+        // Opus has the most history but nothing recent; fable is newest with a single measurement
+        for i in 0..<20 {
+            storage.measurements.append(makeMeasurement(timestamp: nowMs - Int64(i + 48) * oneHourMs, model: "claude-opus-4-6"))
         }
+        for i in 0..<5 {
+            storage.measurements.append(makeMeasurement(timestamp: nowMs - Int64(i + 2) * oneHourMs, model: "claude-sonnet-4-6"))
+        }
+        storage.measurements.append(makeMeasurement(timestamp: nowMs, model: "claude-fable-5"))
+
+        let service = TPPChartDataService(tppStorage: storage)
+        let models = try await service.availableModels()
+
+        #expect(models == ["claude-fable-5", "claude-sonnet-4-6", "claude-opus-4-6"])
+    }
+
+    @Test("Model discovery: equal recency falls back to measurement count")
+    func modelDiscoveryTieBreak() async throws {
+        let storage = MockChartTPPStorage()
         for i in 0..<3 {
-            storage.measurements.append(makeMeasurement(timestamp: nowMs - Int64(i) * oneHourMs, model: "claude-opus-4-6"))
+            storage.measurements.append(makeMeasurement(timestamp: nowMs - Int64(i) * oneHourMs, model: "claude-sonnet-4-6"))
         }
         storage.measurements.append(makeMeasurement(timestamp: nowMs, model: "claude-haiku-4-5"))
 
         let service = TPPChartDataService(tppStorage: storage)
         let models = try await service.availableModels()
 
-        #expect(models.count == 3)
-        #expect(models.first == "claude-sonnet-4-6")
-        #expect(models.last == "claude-haiku-4-5")
+        #expect(models == ["claude-sonnet-4-6", "claude-haiku-4-5"])
     }
 
     // MARK: - Weighting Discovery


### PR DESCRIPTION
## Summary

Release PR for Epic 21 (Fable Model Usage Tracking). Feature work for Stories 21.1–21.5 is already on `master`; this PR carries the README update, one small Token Efficiency fix, and the `[minor]` version bump (1.5.1 → 1.6.0).

**README changes**
- Popover Detail: new "Model-scoped caps" bullet — separate gauge for per-model weekly limits (e.g. Claude Fable 5), labeled from the API, own reset countdown, hidden when the plan reports none.
- Analytics: historical charts gain a toggleable model-scoped series.
- Notifications: threshold alerts now cover the 5h, 7d, and model-scoped windows.
- "How It Works" diagram: usage response now includes model-scoped limits.
- Caption under the demo GIF noting it predates model-scoped caps (recording to be refreshed later).

**Token Efficiency chart** (`TPPChartDataService.availableModels`)
- Model picker is now ordered by most recent measurement (newest first; count breaks ties) instead of by measurement count, and the default selection follows it. Previously the model with the most history (old Opus) was selected by default; now the model in current use (Fable) is. No model names hardcoded.

**What ships in 1.6.0** (already merged)
- Parse the usage API `limits` array generically; drop dead `seven_day_sonnet` parsing.
- Popover gauge for the model-scoped weekly cap with reset countdown.
- Additive persistence columns and a Fable analytics series toggle.
- 20% / 5% headroom notifications for the scoped window, independent dedup, re-arm on recovery.
- Token Efficiency benchmark measures `claude-fable-5` by default; copy notes it draws on the Fable weekly cap.
- Test fix: date-independent `chronicUnderpowering` fixture.

## Release mechanics

`[minor]` in the title triggers the pre-merge version bump on this branch (already pushed: `chore: bump version to 1.6.0`); the post-merge workflow publishes the GitHub release once merged.
