### PR TITLE
ci: use symbol form for cask depends_on macos (Homebrew deprecation)

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -336,7 +336,7 @@ jobs:
             desc "Menu bar utility showing Claude API usage headroom"
             homepage "https://github.com/rajish/cc-hdrm"
 
-            depends_on macos: ">= :sonoma"
+            depends_on macos: :sonoma
 
             app "cc-hdrm.app"
 


### PR DESCRIPTION
## Summary

Homebrew warns on every `brew` operation touching the tap:

> Calling string comparison format for `depends_on macos:` is deprecated! Use `depends_on macos: :sonoma` instead.

The cask is generated by `release-publish.yml`, so this switches the template from `depends_on macos: ">= :sonoma"` to `depends_on macos: :sonoma` (Homebrew's stated replacement — symbol form means "this version or later"). Future releases regenerate the cask without the warning.

The currently published cask in `rajish/homebrew-tap` is fixed separately so the warning stops now, not only at the next release.

No app code changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Homebrew installation requirements to specify macOS Sonoma as the minimum supported version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->